### PR TITLE
Fix logging without subuser

### DIFF
--- a/scripts/allow_null_subuser_id.py
+++ b/scripts/allow_null_subuser_id.py
@@ -1,0 +1,15 @@
+import os
+from sqlalchemy import create_engine, text
+
+DATABASE_URL = os.getenv('DATABASE_URL')
+if not DATABASE_URL:
+    raise SystemExit('DATABASE_URL environment variable not set')
+
+def main():
+    engine = create_engine(DATABASE_URL)
+    with engine.begin() as conn:
+        conn.execute(text('ALTER TABLE sub_user_action ALTER COLUMN subuser_id DROP NOT NULL;'))
+    print('sub_user_action.subuser_id column altered to allow NULL values')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- allow machine action logging even when no subuser is assigned
- provide helper script to alter `sub_user_action.subuser_id` to allow NULL values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686337023758832699dfe54c7a2e1f95