### PR TITLE
Fix flash message rendering in templates

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -34,6 +34,14 @@
 </head>
 <body class="bg-gradient-to-br from-blue-100 to-white min-h-screen pt-4 px-4 flex flex-col justify-between overflow-x-hidden">
 
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% for category, message in messages %}
+      <div class="text-sm text-center px-4 py-2 rounded-xl {{ 'bg-green-100 text-green-800' if category == 'success' else 'bg-red-100 text-red-800' }}">
+        {{ message }}
+      </div>
+    {% endfor %}
+  {% endwith %}
+
   <!-- Main Box -->
   <div class="bg-white/30 backdrop-blur-xl border border-white/20 rounded-2xl shadow-xl 
               w-full max-w-xl mx-auto text-center px-6 sm:px-10 pt-8 pb-28 mt-2 relative overflow-hidden">

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -62,6 +62,8 @@
             }
           });
         </script>
+      {% else %}
+        <div class="text-sm text-red-600 mb-4 text-center">{{ message }}</div>
       {% endif %}
     {% endfor %}
   {% endwith %}
@@ -79,14 +81,7 @@
       Know your machine’s full service history, upcoming maintenance needs, and past component changes — all in one place with just one tap or scan.
     </p>
 
-    <!-- Danger Message for invalid credentials -->
-    {% with messages = get_flashed_messages(with_categories=true) %}
-      {% for category, message in messages %}
-        {% if category == 'danger' %}
-          <div class="text-sm text-red-600 mb-4 text-center">{{ message }}</div>
-        {% endif %}
-      {% endfor %}
-    {% endwith %}
+
 
     <!-- Login Form -->
     <form method="POST" class="space-y-4 text-left px-4">

--- a/app/templates/machine_dashboard.html
+++ b/app/templates/machine_dashboard.html
@@ -9,6 +9,14 @@
   <a href="{{ url_for('routes.user_dashboard') }}" class="inline-block mb-6 text-blue-600 hover:underline">&larr; Back to Dashboard</a>
   <h1 class="text-3xl font-bold mb-8">🖥️ Machine Dashboard</h1>
 
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% for category, message in messages %}
+      <div class="text-sm text-center px-4 py-2 rounded-xl {{ 'bg-green-100 text-green-800' if category == 'success' else 'bg-red-100 text-red-800' }}">
+        {{ message }}
+      </div>
+    {% endfor %}
+  {% endwith %}
+
   {% for data in machines_data %}
   <div id="machine-{{ data.machine.id }}" class="mb-14 bg-white rounded-xl shadow-xl p-6 border border-gray-200">
 

--- a/app/templates/machine_overview.html
+++ b/app/templates/machine_overview.html
@@ -15,6 +15,14 @@
     <p class="text-slate-600">Detailed performance and maintenance logs</p>
   </div>
 
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% for category, message in messages %}
+      <div class="text-sm text-center px-4 py-2 rounded-xl {{ 'bg-green-100 text-green-800' if category == 'success' else 'bg-red-100 text-red-800' }}">
+        {{ message }}
+      </div>
+    {% endfor %}
+  {% endwith %}
+
   <!-- Machine Info -->
   <div class="max-w-3xl mx-auto bg-white/80 backdrop-blur-md shadow rounded-xl p-6 border border-slate-200 mb-6">
     <h2 class="text-xl font-semibold text-slate-800 mb-4">Machine Details</h2>

--- a/app/templates/scan_qr.html
+++ b/app/templates/scan_qr.html
@@ -6,6 +6,13 @@
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-blue-50 min-h-screen flex flex-col items-center justify-center">
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% for category, message in messages %}
+      <div class="text-sm text-center px-4 py-2 rounded-xl {{ 'bg-green-100 text-green-800' if category == 'success' else 'bg-red-100 text-red-800' }}">
+        {{ message }}
+      </div>
+    {% endfor %}
+  {% endwith %}
   <div class="bg-white rounded-2xl shadow-xl p-8 max-w-md w-full text-center border border-blue-200">
     <h1 class="text-2xl font-bold mb-4 text-blue-800">Scan QR or Enter Code</h1>
     <p class="mb-4 text-slate-600">Scan the admin QR code with your device, or enter the code below:</p>

--- a/app/templates/user_dashboard.html
+++ b/app/templates/user_dashboard.html
@@ -48,6 +48,14 @@
   </div>
 {% endif %}
 
+{% with messages = get_flashed_messages(with_categories=true) %}
+  {% for category, message in messages %}
+    <div class="text-sm text-center px-4 py-2 rounded-xl {{ 'bg-green-100 text-green-800' if category == 'success' else 'bg-red-100 text-red-800' }}">
+      {{ message }}
+    </div>
+  {% endfor %}
+{% endwith %}
+
 <!-- Logo + Welcome -->
 <div class="max-w-2xl mx-auto mb-2">
   <div class="flex justify-start items-center">


### PR DESCRIPTION
## Summary
- show flash messages on all pages so they don't accumulate
- consolidate flash handling in `login.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68635502a6b8832688f0a366c32ab955