### PR TITLE
Add manual batch and machine creation in settings

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -72,12 +72,13 @@ def scan_qr_page():
 @routes.route("/user/create-batch", methods=["POST"])
 @login_required
 def user_create_batch():
-    # Prevent duplicate batch for user
-    if QRBatch.query.filter_by(owner_id=current_user.id).count() > 0:
-        flash("You already have a batch.", "info")
-        return redirect(url_for("routes.user_dashboard"))
+    """Allow users to generate additional QR batches."""
     batch_id = generate_and_store_qr_batch(user_id=current_user.id)
     flash("QR batch generated! You can now set up your machine.", "success")
+
+    next_url = request.args.get("next")
+    if next_url:
+        return redirect(next_url)
     return redirect(url_for("routes.user_dashboard"))
 
 @routes.route("/machine/<int:machine_id>/mark/<action>")
@@ -319,6 +320,24 @@ def claim_batch(batch_id):
 @login_required
 def user_settings():
     if request.method == "POST":
+        # --- Adding a machine for an unregistered batch ---
+        if request.form.get("batch_id") and request.form.get("name"):
+            batch_id = request.form.get("batch_id")
+            name = request.form.get("name") or current_user.default_machine_name or "Unnamed Machine"
+            mtype = request.form.get("type") or current_user.default_machine_location or "General"
+
+            existing = Machine.query.filter_by(batch_id=batch_id).first()
+            if existing:
+                existing.name = name
+                existing.type = mtype
+                flash("Machine updated with your preferences.", "success")
+            else:
+                machine = Machine(batch_id=batch_id, name=name, type=mtype)
+                db.session.add(machine)
+                flash("Machine added successfully.", "success")
+            db.session.commit()
+            return redirect(url_for("routes.user_settings"))
+
         # --- User Account Fields ---
         name = request.form.get("name")
         company_name = request.form.get("company_name")
@@ -365,15 +384,17 @@ def user_settings():
         flash("All settings updated successfully.", "success")
         return redirect(url_for("routes.user_settings"))
 
-    # --- GET: Load machines ---
+    # --- GET: Load machines and batches ---
     user_batches = QRBatch.query.filter_by(owner_id=current_user.id).all()
     machines = []
     for batch in user_batches:
         m = Machine.query.filter_by(batch_id=batch.id).first()
         if m:
             machines.append(m)
+        # Attach machine reference for template convenience
+        batch.machine = m
 
-    return render_template("user_settings.html", machines=machines)
+    return render_template("user_settings.html", machines=machines, batches=user_batches)
 
 @routes.route("/signup", methods=["GET", "POST"], endpoint="user_signup")
 def user_signup():

--- a/app/templates/user_settings.html
+++ b/app/templates/user_settings.html
@@ -108,6 +108,26 @@
 
       <!-- Machines Section -->
       <div id="section-machines" data-section class="hidden">
+        <div class="mb-6 text-center">
+          <form method="POST" action="{{ url_for('routes.user_create_batch', next=url_for('routes.user_settings')) }}">
+            <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded-xl font-semibold hover:bg-blue-700 shadow">Generate New QR Batch</button>
+          </form>
+        </div>
+
+        {% for batch in batches %}
+          {% if not batch.machine %}
+          <div class="bg-blue-50 border border-blue-200 p-4 rounded-xl mb-4 text-center">
+            <h2 class="text-lg font-bold mb-2 text-blue-800">Machine details to register</h2>
+            <form method="POST" action="{{ url_for('routes.user_settings') }}" class="flex flex-col gap-2 items-center">
+              <input type="hidden" name="batch_id" value="{{ batch.id }}">
+              <input type="text" name="name" placeholder="Enter machine name" class="px-4 py-2 rounded border" required>
+              <input type="text" name="type" placeholder="Machine type (e.g. Model/Location)" class="px-4 py-2 rounded border" required>
+              <button type="submit" class="px-4 py-2 rounded bg-blue-600 text-white font-semibold hover:bg-blue-700 transition">Add Machine</button>
+            </form>
+          </div>
+          {% endif %}
+        {% endfor %}
+
         {% for machine in machines %}
         <div class="bg-white/30 backdrop-blur-md border border-white/20 p-5 rounded-xl space-y-4 shadow mb-4">
           <h2 class="text-lg font-semibold">🛠️ Machine</h2>


### PR DESCRIPTION
## Summary
- allow multiple QR batch generation with optional redirect
- enable adding machines for unregistered batches via settings
- show button to generate new batches and display pending batch forms

## Testing
- `python -m py_compile app/routes.py app/models.py app/utils.py app/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68635ae8d278832690bc31b3b3fabf7f