### PR TITLE
Fix tab initialization

### DIFF
--- a/app/templates/user_settings.html
+++ b/app/templates/user_settings.html
@@ -165,7 +165,8 @@
   <script>
     // Set default tab on page load
     document.addEventListener('DOMContentLoaded', () => {
-      showTab('{{ default_tab }}');
+      const urlTab = new URLSearchParams(window.location.search).get('tab');
+      showTab(urlTab || '{{ default_tab }}');
 
       // Eye icon show/hide logic
       const passwordInput = document.getElementById('passwordInput');


### PR DESCRIPTION
## Summary
- preserve URL `tab` parameter when initializing tabs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68636b03a03c832694665e90ed1ac9c6