### PR TITLE
Separate machine actions from settings form

### DIFF
--- a/app/templates/user_settings.html
+++ b/app/templates/user_settings.html
@@ -11,6 +11,11 @@
       sections.forEach(s => s.classList.add('hidden'));
       document.getElementById(`section-${tab}`).classList.remove('hidden');
 
+      const extraSections = document.querySelectorAll('[data-extra-section]');
+      extraSections.forEach(s => s.classList.add('hidden'));
+      const extra = document.getElementById(`extra-${tab}`);
+      if (extra) extra.classList.remove('hidden');
+
       const tabs = document.querySelectorAll('[data-tab]');
       tabs.forEach(t => t.classList.remove('border-blue-500', 'text-blue-700'));
       document.getElementById(`tab-${tab}`).classList.add('border-blue-500', 'text-blue-700');
@@ -108,32 +113,6 @@
 
       <!-- Machines Section -->
       <div id="section-machines" data-section class="hidden">
-        <div class="mb-6 text-center">
-          <form id="generateBatchForm" method="POST" action="{{ url_for('routes.user_create_batch', next=url_for('routes.user_settings', tab='machines')) }}" onsubmit="showGeneratingState(event)">
-            <button id="generateBtn" type="submit" class="bg-blue-600 text-white px-4 py-2 rounded-xl font-semibold hover:bg-blue-700 shadow flex items-center justify-center gap-2">
-              <span id="generateText">Generate New QR Batch</span>
-              <svg id="spinner" class="hidden animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
-              </svg>
-            </button>
-          </form>
-        </div>
-
-        {% for batch in batches %}
-          {% if not batch.machine %}
-          <div class="bg-blue-50 border border-blue-200 p-4 rounded-xl mb-4 text-center">
-            <h2 class="text-lg font-bold mb-2 text-blue-800">Machine details to register</h2>
-            <form method="POST" action="{{ url_for('routes.user_settings') }}" class="flex flex-col gap-2 items-center">
-              <input type="hidden" name="batch_id" value="{{ batch.id }}">
-              <input type="text" name="name" placeholder="Enter machine name" class="px-4 py-2 rounded border" required>
-              <input type="text" name="type" placeholder="Machine type (e.g. Model/Location)" class="px-4 py-2 rounded border" required>
-              <button type="submit" class="px-4 py-2 rounded bg-blue-600 text-white font-semibold hover:bg-blue-700 transition">Add Machine</button>
-            </form>
-          </div>
-          {% endif %}
-        {% endfor %}
-
         {% for machine in machines %}
         <div class="bg-white/30 backdrop-blur-md border border-white/20 p-5 rounded-xl space-y-4 shadow mb-4">
           <h2 class="text-lg font-semibold">🛠️ Machine</h2>
@@ -153,13 +132,40 @@
         </div>
         {% endfor %}
       </div>
-
-      <!-- Save Button -->
       <button type="submit"
               class="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl py-2 shadow">
         Save All Settings
       </button>
     </form>
+
+    <!-- Machines Actions outside main form -->
+    <div id="extra-machines" data-extra-section class="hidden">
+      <div class="mb-6 text-center">
+        <form id="generateBatchForm" method="POST" action="{{ url_for('routes.user_create_batch', next=url_for('routes.user_settings', tab='machines')) }}" onsubmit="showGeneratingState(event)">
+          <button id="generateBtn" type="submit" class="bg-blue-600 text-white px-4 py-2 rounded-xl font-semibold hover:bg-blue-700 shadow flex items-center justify-center gap-2">
+            <span id="generateText">Generate New QR Batch</span>
+            <svg id="spinner" class="hidden animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
+            </svg>
+          </button>
+        </form>
+      </div>
+
+      {% for batch in batches %}
+        {% if not batch.machine %}
+        <div class="bg-blue-50 border border-blue-200 p-4 rounded-xl mb-4 text-center">
+          <h2 class="text-lg font-bold mb-2 text-blue-800">Machine details to register</h2>
+          <form method="POST" action="{{ url_for('routes.user_settings') }}" class="flex flex-col gap-2 items-center">
+            <input type="hidden" name="batch_id" value="{{ batch.id }}">
+            <input type="text" name="name" placeholder="Enter machine name" class="px-4 py-2 rounded border" required>
+            <input type="text" name="type" placeholder="Machine type (e.g. Model/Location)" class="px-4 py-2 rounded border" required>
+            <button type="submit" class="px-4 py-2 rounded bg-blue-600 text-white font-semibold hover:bg-blue-700 transition">Add Machine</button>
+          </form>
+        </div>
+        {% endif %}
+      {% endfor %}
+    </div>
   </div>
 
   <script>


### PR DESCRIPTION
## Summary
- avoid nested forms on user settings page
- show/hide extra machine actions when the machines tab is active

## Testing
- `python -m compileall -q app`
- `pytest -q || true`

------
https://chatgpt.com/codex/tasks/task_e_68636b0d031c83268d5e6a281a819542