### PR TITLE
Add quarterly greasing tracking

### DIFF
--- a/app/templates/user_dashboard.html
+++ b/app/templates/user_dashboard.html
@@ -280,6 +280,19 @@
 
           <p class="flex justify-between">
             <span class="flex items-center gap-2">
+              🛢️ Machine Quately Greasing?
+              <span class="{{ 'text-green-600 font-semibold' if machine.quarterly_grease_done else 'text-red-500 font-semibold' }}">
+                {{ 'Yes' if machine.quarterly_grease_done else 'No' }}
+              </span>
+            </span>
+            {% if not machine.quarterly_grease_done %}
+              <a href="{{ url_for('routes.mark_action_done', machine_id=machine.id, action='grease') }}"
+                 class="text-blue-600 hover:underline text-sm">Mark as Done</a>
+            {% endif %}
+          </p>
+
+          <p class="flex justify-between">
+            <span class="flex items-center gap-2">
               🛠️ Service Requested?
               <span class="{{ 'text-green-600 font-semibold' if machine.pending_count == 0 else 'text-red-600 font-semibold' }}">
                 {{ 'No' if machine.pending_count == 0 else machine.pending_count ~ ' pending' }}


### PR DESCRIPTION
## Summary
- support a new `grease` action in `mark_action_done`
- include quarterly greasing status in quick machine overview
- allow marking quarterly greasing from the dashboard

No database schema changes are required. Quarterly greasing records are stored in the existing `sub_user_action` table with `action_type` set to `grease`.

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865dbf13e4083268f7e89a09b366291