### PR TITLE
Improve machine overview

### DIFF
--- a/app/templates/user_dashboard.html
+++ b/app/templates/user_dashboard.html
@@ -240,93 +240,107 @@
 <!-- Quick Machine Overview -->
 <div class="max-w-4xl mx-auto mt-14 px-4">
   <h2 class="text-xl font-bold text-slate-800 mb-4 text-center">🔍 Quick Machine Overview</h2>
-  <div class="flex flex-col sm:flex-row flex-wrap gap-4 justify-center max-w-4xl mx-auto items-start">
-    {% for machine in quick_overview %}
-      {% set status_ok = (machine.pending_count == 0) %}
-      <div class="rounded-xl border shadow bg-white p-4 relative flex flex-col self-start w-full sm:w-[48%] min-h-[200px]">
-        <span class="absolute top-3 right-3 w-3 h-3 rounded-full {{ 'bg-green-500' if status_ok else 'bg-red-500' }}"></span>
-        <h3 class="text-lg font-semibold text-gray-800 mb-1">{{ machine.name }}</h3>
-
+  {% for machine in quick_overview %}
+    {% set idx = loop.index0 %}
+    <div class="mb-8 border rounded-xl shadow bg-white">
+      <div class="px-4 py-2 bg-slate-100 rounded-t-xl flex justify-between items-center">
+        <h3 class="font-semibold text-gray-800">{{ machine.name }}</h3>
         {% if machine.assigned_subuser %}
-          <p class="text-sm text-slate-500 mb-2">Assigned to: {{ machine.assigned_subuser }}</p>
+          <span class="text-sm text-slate-500">Assigned to: {{ machine.assigned_subuser }}</span>
         {% endif %}
-
-        <div class="text-sm space-y-1">
-          <p class="flex justify-between">
-            <span class="flex items-center gap-2">
-              📘 Oiled Today?
-              <span class="{{ 'text-green-600 font-semibold' if machine.oiled_today else 'text-red-500 font-semibold' }}">
-                {{ 'Yes' if machine.oiled_today else 'No' }}
-              </span>
-            </span>
-            {% if not machine.oiled_today %}
-              <a href="{{ url_for('routes.mark_action_done', machine_id=machine.id, action='oil') }}"
-                 class="text-blue-600 hover:underline text-sm">Mark as Done</a>
-            {% endif %}
-          </p>
-
-          <p class="flex justify-between">
-            <span class="flex items-center gap-2">
-              🧴 Lube Done This Week?
-              <span class="{{ 'text-green-600 font-semibold' if machine.weekly_lube_done else 'text-red-500 font-semibold' }}">
-                {{ 'Yes' if machine.weekly_lube_done else 'No' }}
-              </span>
-            </span>
-            {% if not machine.weekly_lube_done %}
-              <a href="{{ url_for('routes.mark_action_done', machine_id=machine.id, action='lube') }}"
-                 class="text-blue-600 hover:underline text-sm">Mark as Done</a>
-            {% endif %}
-          </p>
-
-          <p class="flex justify-between">
-            <span class="flex items-center gap-2">
-              🛢️ Machine Quately Greasing?
-              <span class="{{ 'text-green-600 font-semibold' if machine.quarterly_grease_done else 'text-red-500 font-semibold' }}">
-                {{ 'Yes' if machine.quarterly_grease_done else 'No' }}
-              </span>
-            </span>
-            {% if not machine.quarterly_grease_done %}
-              <a href="{{ url_for('routes.mark_action_done', machine_id=machine.id, action='grease') }}"
-                 class="text-blue-600 hover:underline text-sm">Mark as Done</a>
-            {% endif %}
-          </p>
-
-          <p class="flex justify-between">
-            <span class="flex items-center gap-2">
-              🛠️ Service Requested?
-              <span class="{{ 'text-green-600 font-semibold' if machine.pending_count == 0 else 'text-red-600 font-semibold' }}">
-                {{ 'No' if machine.pending_count == 0 else machine.pending_count ~ ' pending' }}
-              </span>
-            </span>
-            {% if machine.pending_count > 0 %}
-              <span class="text-blue-600 hover:underline cursor-pointer text-sm" onclick="toggleRequests({{ loop.index0 }})">
-                View
-              </span>
-            {% endif %}
-          </p>
-        </div>
-
-        <!-- Expandable Request List -->
-        <div id="requests-{{ loop.index0 }}" class="hidden mt-3 space-y-2 bg-gray-50 p-3 rounded">
-          {% for req in machine.pending_requests %}
-            <div class="border border-gray-200 p-2 rounded-lg">
-              <p class="text-sm"><strong>From:</strong> {{ req.subuser_name or 'Unknown' }}</p>
-              <p class="text-sm"><strong>Heads:</strong> {{ req.heads or 'N/A' }}</p>
-              <p class="text-sm">
-                <strong>Issue:</strong> {{ req.message or req.issue or 'Not specified' }}
-              </p>
-              <p class="text-xs text-gray-500">{{ req.timestamp.strftime('%Y-%m-%d %I:%M %p') }}</p>
-              <form method="POST" action="{{ url_for('routes.resolve_service_request', request_id=req.id) }}" class="mt-1">
-                <button type="submit" class="text-white bg-blue-600 px-3 py-1 rounded hover:bg-blue-700 text-xs transition">Mark Resolved</button>
-              </form>
-            </div>
-          {% else %}
-            <p class="italic text-gray-500 text-sm">No pending requests.</p>
-          {% endfor %}
-        </div>
       </div>
-    {% endfor %}
-  </div>
+      <div class="overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="py-2 px-3 text-left">Task</th>
+              <th class="py-2 px-3 text-left">Status</th>
+              <th class="py-2 px-3 text-left">Last Done</th>
+              <th class="py-2 px-3 text-left">Next Due</th>
+              <th class="py-2 px-3 text-left">Action</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y">
+            <tr>
+              <td class="py-2 px-3">📘 Oiling</td>
+              <td>
+                <span class="{{ 'text-green-600 font-semibold' if machine.oiled_today else 'text-red-500 font-semibold' }}">
+                  {{ 'Done' if machine.oiled_today else 'Pending' }}
+                </span>
+              </td>
+              <td><span data-utc="{{ machine.last_oil_time.isoformat() if machine.last_oil_time else '' }}"></span></td>
+              <td><span data-utc="{{ machine.next_oil_due.isoformat() if machine.next_oil_due else '' }}"></span></td>
+              <td>
+                {% if not machine.oiled_today %}
+                  <a href="{{ url_for('routes.mark_action_done', machine_id=machine.id, action='oil') }}" class="text-blue-600 hover:underline">Mark as Done</a>
+                {% else %}Done{% endif %}
+              </td>
+            </tr>
+            <tr>
+              <td class="py-2 px-3">🧴 Lube</td>
+              <td>
+                <span class="{{ 'text-green-600 font-semibold' if machine.weekly_lube_done else 'text-red-500 font-semibold' }}">
+                  {{ 'Done' if machine.weekly_lube_done else 'Pending' }}
+                </span>
+              </td>
+              <td><span data-utc="{{ machine.last_lube_time.isoformat() if machine.last_lube_time else '' }}"></span></td>
+              <td><span data-utc="{{ machine.next_lube_due.isoformat() if machine.next_lube_due else '' }}"></span></td>
+              <td>
+                {% if not machine.weekly_lube_done %}
+                  <a href="{{ url_for('routes.mark_action_done', machine_id=machine.id, action='lube') }}" class="text-blue-600 hover:underline">Mark as Done</a>
+                {% else %}Done{% endif %}
+              </td>
+            </tr>
+            <tr>
+              <td class="py-2 px-3">🛢️ Greasing</td>
+              <td>
+                <span class="{{ 'text-green-600 font-semibold' if machine.quarterly_grease_done else 'text-red-500 font-semibold' }}">
+                  {{ 'Done' if machine.quarterly_grease_done else 'Pending' }}
+                </span>
+              </td>
+              <td><span data-utc="{{ machine.last_grease_time.isoformat() if machine.last_grease_time else '' }}"></span></td>
+              <td><span data-utc="{{ machine.next_grease_due.isoformat() if machine.next_grease_due else '' }}"></span></td>
+              <td>
+                {% if not machine.quarterly_grease_done %}
+                  <a href="{{ url_for('routes.mark_action_done', machine_id=machine.id, action='grease') }}" class="text-blue-600 hover:underline">Mark as Done</a>
+                {% else %}Done{% endif %}
+              </td>
+            </tr>
+            <tr>
+              <td class="py-2 px-3">🛠️ Service</td>
+              <td>
+                <span class="{{ 'text-green-600 font-semibold' if machine.pending_count == 0 else 'text-red-600 font-semibold' }}">
+                  {{ 'No pending' if machine.pending_count == 0 else machine.pending_count ~ ' pending' }}
+                </span>
+              </td>
+              <td><span data-utc="{{ machine.last_service_time.isoformat() if machine.last_service_time else '' }}"></span></td>
+              <td><span data-utc="{{ machine.next_service_due.isoformat() if machine.next_service_due else '' }}"></span></td>
+              <td>
+                {% if machine.pending_count > 0 %}
+                  <span class="text-blue-600 hover:underline cursor-pointer" onclick="toggleRequests({{ idx }})">View</span>
+                {% else %}Done{% endif %}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div id="requests-{{ idx }}" class="hidden mt-3 space-y-2 bg-gray-50 p-3 rounded-b-xl">
+        {% for req in machine.pending_requests %}
+          <div class="border border-gray-200 p-2 rounded-lg">
+            <p class="text-sm"><strong>From:</strong> {{ req.subuser_name or 'Unknown' }}</p>
+            <p class="text-sm"><strong>Heads:</strong> {{ req.heads or 'N/A' }}</p>
+            <p class="text-sm"><strong>Issue:</strong> {{ req.message or req.issue or 'Not specified' }}</p>
+            <p class="text-xs text-gray-500"><span data-utc="{{ req.timestamp.isoformat() }}"></span></p>
+            <form method="POST" action="{{ url_for('routes.resolve_service_request', request_id=req.id) }}" class="mt-1">
+              <button type="submit" class="text-white bg-blue-600 px-3 py-1 rounded hover:bg-blue-700 text-xs transition">Mark Resolved</button>
+            </form>
+          </div>
+        {% else %}
+          <p class="italic text-gray-500 text-sm">No pending requests.</p>
+        {% endfor %}
+      </div>
+    </div>
+  {% endfor %}
 </div>
 
 <script>


### PR DESCRIPTION
## Summary
- replace card list with a table of tasks on the dashboard
- keep service requests expandable
- expose last/due dates for maintenance actions

## Testing
- `python -m py_compile app/routes.py`

------
https://chatgpt.com/codex/tasks/task_e_6865e439c3148326a9f03a0f9f21d8ad