### PR TITLE
Add client-side UTC conversion

### DIFF
--- a/app/templates/user_dashboard.html
+++ b/app/templates/user_dashboard.html
@@ -315,7 +315,7 @@
               <p class="text-sm">
                 <strong>Issue:</strong> {{ req.message or req.issue or 'Not specified' }}
               </p>
-              <p class="text-xs text-gray-500">{{ req.timestamp.strftime('%Y-%m-%d %I:%M %p') }}</p>
+              <p class="text-xs text-gray-500" data-utc="{{ req.timestamp.isoformat() }}"></p>
               <form method="POST" action="{{ url_for('routes.resolve_service_request', request_id=req.id) }}" class="mt-1">
                 <button type="submit" class="text-white bg-blue-600 px-3 py-1 rounded hover:bg-blue-700 text-xs transition">Mark Resolved</button>
               </form>
@@ -360,5 +360,6 @@
     }, 500); // slight delay for visual feedback
   }
 </script>
+<script src="{{ url_for('static', filename='js/localtime.js') }}"></script>
 </body>
 </html>

--- a/static/js/localtime.js
+++ b/static/js/localtime.js
@@ -1,0 +1,19 @@
+// Convert UTC timestamps in elements with data-utc to local time
+// Format: 01 Jan '25 10:00 am
+
+document.addEventListener('DOMContentLoaded', () => {
+  const elements = document.querySelectorAll('[data-utc]');
+  elements.forEach(el => {
+    let iso = el.getAttribute('data-utc');
+    if (!iso) return;
+    if (!iso.endsWith('Z') && !iso.includes('+')) {
+      iso += 'Z';
+    }
+    const date = new Date(iso);
+    if (isNaN(date)) return;
+    const dayMonth = new Intl.DateTimeFormat('en-GB', { day: '2-digit', month: 'short' }).format(date);
+    const year = new Intl.DateTimeFormat('en-US', { year: '2-digit' }).format(date);
+    const time = new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: '2-digit', hour12: true }).format(date).toLowerCase();
+    el.textContent = `${dayMonth} '${year} ${time}`;
+  });
+});


### PR DESCRIPTION
## Summary
- show local times for pending requests using a small JavaScript helper
- insert the script on the user dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e4582d608326b15b6a95768e9d4e