### PR TITLE
Add login protection to mark_action_done route

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -83,6 +83,7 @@ def user_create_batch():
 
 
 @routes.route("/machine/<int:machine_id>/mark/<action>")
+@login_required
 def mark_action_done(machine_id, action):
     # Fetch machine and validate existence
     machine = Machine.query.get_or_404(machine_id)


### PR DESCRIPTION
## Summary
- ensure only logged in users can mark machine actions done

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e45ff350832694ab4c5e1dcdb3bb