### PR TITLE
Fix missing timestamps in machine overview

### DIFF
--- a/app/templates/user_dashboard.html
+++ b/app/templates/user_dashboard.html
@@ -373,6 +373,18 @@
       event.target.submit();
     }, 500); // slight delay for visual feedback
   }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('[data-utc]').forEach(el => {
+      const utc = el.getAttribute('data-utc');
+      if (utc) {
+        const date = new Date(utc + 'Z');
+        el.textContent = date.toLocaleString();
+      } else {
+        el.textContent = '—';
+      }
+    });
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show last and next maintenance timestamps in user dashboard
- convert UTC strings to local time via JavaScript

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e8d2b4348326aa2b2e4c930a2e8b