### PR TITLE
Update Quick Machine Overview

### DIFF
--- a/app/templates/user_dashboard.html
+++ b/app/templates/user_dashboard.html
@@ -253,67 +253,66 @@
         <table class="min-w-full text-sm table-auto">
           <thead class="bg-gray-50">
             <tr class="text-gray-700">
-              <th class="py-2 px-3 text-left font-semibold">Task</th>
-              <th class="py-2 px-3 text-left font-semibold">Status</th>
+              <th class="py-2 px-3 text-left font-semibold">Task / Status</th>
               <th class="py-2 px-3 text-left font-semibold">Next Due</th>
               <th class="py-2 px-3 text-left font-semibold">Action</th>
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-200">
             <tr>
-              <td class="py-2 px-3 align-top">Daily Oil Check</td>
               <td class="py-2 px-3 align-top">
-                <span class="{{ 'text-green-600 font-semibold' if machine.oiled_today else 'text-red-500 font-semibold' }}">
-                  {{ 'Done' if machine.oiled_today else 'Pending' }}
-                </span>
+                <div class="flex flex-col">
+                  <span>Daily Oil Check</span>
+                  <span class="{{ 'text-green-600 font-medium text-xs' if machine.oiled_today else 'text-red-500 font-medium text-xs' }}">Status: {{ 'Done' if machine.oiled_today else 'Pending' }}</span>
+                </div>
               </td>
               <td class="py-2 px-3 align-top"><span data-utc="{{ machine.next_oil_due.isoformat() if machine.next_oil_due else '' }}"></span></td>
               <td class="py-2 px-3 align-top">
                 {% if not machine.oiled_today %}
-                  <a href="{{ url_for('routes.mark_action_done', machine_id=machine.id, action='oil') }}" class="text-blue-600 hover:underline">Mark as Done</a>
-                {% else %}Done{% endif %}
+                  <a href="{{ url_for('routes.mark_action_done', machine_id=machine.id, action='oil') }}" class="bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700 text-xs transition">Mark as Done</a>
+                {% else %}<span class="text-green-600 text-xs font-semibold">Done</span>{% endif %}
               </td>
             </tr>
             <tr>
-              <td class="py-2 px-3 align-top">Weekly Lubrication</td>
               <td class="py-2 px-3 align-top">
-                <span class="{{ 'text-green-600 font-semibold' if machine.weekly_lube_done else 'text-red-500 font-semibold' }}">
-                  {{ 'Done' if machine.weekly_lube_done else 'Pending' }}
-                </span>
+                <div class="flex flex-col">
+                  <span>Weekly Lubrication</span>
+                  <span class="{{ 'text-green-600 font-medium text-xs' if machine.weekly_lube_done else 'text-red-500 font-medium text-xs' }}">Status: {{ 'Done' if machine.weekly_lube_done else 'Pending' }}</span>
+                </div>
               </td>
               <td class="py-2 px-3 align-top"><span data-utc="{{ machine.next_lube_due.isoformat() if machine.next_lube_due else '' }}"></span></td>
               <td class="py-2 px-3 align-top">
                 {% if not machine.weekly_lube_done %}
-                  <a href="{{ url_for('routes.mark_action_done', machine_id=machine.id, action='lube') }}" class="text-blue-600 hover:underline">Mark as Done</a>
-                {% else %}Done{% endif %}
+                  <a href="{{ url_for('routes.mark_action_done', machine_id=machine.id, action='lube') }}" class="bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700 text-xs transition">Mark as Done</a>
+                {% else %}<span class="text-green-600 text-xs font-semibold">Done</span>{% endif %}
               </td>
             </tr>
             <tr>
-              <td class="py-2 px-3 align-top">Quarterly Greasing</td>
               <td class="py-2 px-3 align-top">
-                <span class="{{ 'text-green-600 font-semibold' if machine.quarterly_grease_done else 'text-red-500 font-semibold' }}">
-                  {{ 'Done' if machine.quarterly_grease_done else 'Pending' }}
-                </span>
+                <div class="flex flex-col">
+                  <span>Quarterly Greasing</span>
+                  <span class="{{ 'text-green-600 font-medium text-xs' if machine.quarterly_grease_done else 'text-red-500 font-medium text-xs' }}">Status: {{ 'Done' if machine.quarterly_grease_done else 'Pending' }}</span>
+                </div>
               </td>
               <td class="py-2 px-3 align-top"><span data-utc="{{ machine.next_grease_due.isoformat() if machine.next_grease_due else '' }}"></span></td>
               <td class="py-2 px-3 align-top">
                 {% if not machine.quarterly_grease_done %}
-                  <a href="{{ url_for('routes.mark_action_done', machine_id=machine.id, action='grease') }}" class="text-blue-600 hover:underline">Mark as Done</a>
-                {% else %}Done{% endif %}
+                  <a href="{{ url_for('routes.mark_action_done', machine_id=machine.id, action='grease') }}" class="bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700 text-xs transition">Mark as Done</a>
+                {% else %}<span class="text-green-600 text-xs font-semibold">Done</span>{% endif %}
               </td>
             </tr>
             <tr>
-              <td class="py-2 px-3 align-top">Service Requests</td>
               <td class="py-2 px-3 align-top">
-                <span class="{{ 'text-green-600 font-semibold' if machine.pending_count == 0 else 'text-red-600 font-semibold' }}">
-                  {{ 'No pending' if machine.pending_count == 0 else machine.pending_count ~ ' pending' }}
-                </span>
+                <div class="flex flex-col">
+                  <span>Service Requests</span>
+                  <span class="{{ 'text-green-600 font-medium text-xs' if machine.pending_count == 0 else 'text-red-600 font-medium text-xs' }}">Status: {{ 'No pending' if machine.pending_count == 0 else machine.pending_count ~ ' pending' }}</span>
+                </div>
               </td>
               <td class="py-2 px-3 align-top"><span data-utc="{{ machine.next_service_due.isoformat() if machine.next_service_due else '' }}"></span></td>
               <td class="py-2 px-3 align-top">
                 {% if machine.pending_count > 0 %}
-                  <span class="text-blue-600 hover:underline cursor-pointer" onclick="toggleRequests({{ idx }})">View</span>
-                {% else %}Done{% endif %}
+                  <span class="text-blue-600 hover:underline cursor-pointer text-xs" onclick="toggleRequests({{ idx }})">View</span>
+                {% else %}<span class="text-green-600 text-xs font-semibold">Done</span>{% endif %}
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
## Summary
- show task name and status in the same column for quick overview table
- convert action links to styled buttons

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865fd0ac5ac832699be1582a7de76b8