### PR TITLE
Add configurable maintenance intervals

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -60,6 +60,10 @@ class Machine(db.Model):
     name = db.Column(db.String(100))
     type = db.Column(db.String(100))
     under_maintenance = db.Column(db.Boolean, default=False)
+    # New: user configurable maintenance intervals
+    oil_interval_hours = db.Column(db.Integer, default=24)
+    lube_interval_days = db.Column(db.Integer, default=7)
+    grease_interval_months = db.Column(db.Integer, default=3)
 
     maintenance_logs = db.relationship("DailyMaintenance", backref="machine", lazy=True)
     service_requests = db.relationship("ServiceRequest", backref="machine", lazy=True)

--- a/app/templates/user_dashboard.html
+++ b/app/templates/user_dashboard.html
@@ -266,7 +266,7 @@
                   <span class="{{ 'text-green-600 font-medium text-xs' if machine.oiled_today else 'text-red-500 font-medium text-xs' }}">Status: {{ 'Done' if machine.oiled_today else 'Pending' }}</span>
                 </div>
               </td>
-              <td class="py-2 px-3 align-top"><span data-utc="{{ machine.next_oil_due.isoformat() if machine.next_oil_due else '' }}"></span></td>
+              <td class="py-2 px-3 align-top">{{ machine.next_oil_due_str or '—' }}</td>
               <td class="py-2 px-3 align-top">
                 {% if not machine.oiled_today %}
                   <a href="{{ url_for('routes.mark_action_done', machine_id=machine.id, action='oil') }}" class="bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700 text-xs transition">Mark as Done</a>
@@ -280,7 +280,7 @@
                   <span class="{{ 'text-green-600 font-medium text-xs' if machine.weekly_lube_done else 'text-red-500 font-medium text-xs' }}">Status: {{ 'Done' if machine.weekly_lube_done else 'Pending' }}</span>
                 </div>
               </td>
-              <td class="py-2 px-3 align-top"><span data-utc="{{ machine.next_lube_due.isoformat() if machine.next_lube_due else '' }}"></span></td>
+              <td class="py-2 px-3 align-top">{{ machine.next_lube_due_str or '—' }}</td>
               <td class="py-2 px-3 align-top">
                 {% if not machine.weekly_lube_done %}
                   <a href="{{ url_for('routes.mark_action_done', machine_id=machine.id, action='lube') }}" class="bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700 text-xs transition">Mark as Done</a>
@@ -294,7 +294,7 @@
                   <span class="{{ 'text-green-600 font-medium text-xs' if machine.quarterly_grease_done else 'text-red-500 font-medium text-xs' }}">Status: {{ 'Done' if machine.quarterly_grease_done else 'Pending' }}</span>
                 </div>
               </td>
-              <td class="py-2 px-3 align-top"><span data-utc="{{ machine.next_grease_due.isoformat() if machine.next_grease_due else '' }}"></span></td>
+              <td class="py-2 px-3 align-top">{{ machine.next_grease_due_str or '—' }}</td>
               <td class="py-2 px-3 align-top">
                 {% if not machine.quarterly_grease_done %}
                   <a href="{{ url_for('routes.mark_action_done', machine_id=machine.id, action='grease') }}" class="bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700 text-xs transition">Mark as Done</a>

--- a/app/templates/user_settings.html
+++ b/app/templates/user_settings.html
@@ -129,6 +129,20 @@
             <input type="text" name="machine_type_{{ machine.id }}" value="{{ machine.type }}"
                    class="w-full px-4 py-2 rounded-xl bg-white/60 border border-white/30 shadow-inner">
           </div>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div>
+              <label class="block text-sm mb-1">Hours between Oil</label>
+              <input type="number" min="1" name="oil_interval_{{ machine.id }}" value="{{ machine.oil_interval_hours }}" class="w-full px-3 py-2 rounded-xl bg-white/60 border border-white/30 shadow-inner">
+            </div>
+            <div>
+              <label class="block text-sm mb-1">Days between Lube</label>
+              <input type="number" min="1" name="lube_interval_{{ machine.id }}" value="{{ machine.lube_interval_days }}" class="w-full px-3 py-2 rounded-xl bg-white/60 border border-white/30 shadow-inner">
+            </div>
+            <div>
+              <label class="block text-sm mb-1">Months between Grease</label>
+              <input type="number" min="1" name="grease_interval_{{ machine.id }}" value="{{ machine.grease_interval_months }}" class="w-full px-3 py-2 rounded-xl bg-white/60 border border-white/30 shadow-inner">
+            </div>
+          </div>
         </div>
         {% endfor %}
       </div>


### PR DESCRIPTION
## Summary
- allow per-machine maintenance intervals
- show next due in human-readable form on dashboard
- update settings UI for interval inputs

## Testing
- `python -m py_compile app/models.py app/routes.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68671a5176948326ba1c1150790234ed