### PR TITLE
Add machine maintenance columns script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Maintaineh
+
+## Database migrations
+
+Some schema updates are handled through small scripts in the `scripts/` directory. After deploying a new version that introduces machine maintenance intervals, run:
+
+```bash
+python scripts/add_machine_maintenance_columns.py
+```
+
+The script connects to the database specified by the `DATABASE_URL` environment variable and adds the necessary columns if they do not already exist.

--- a/scripts/add_machine_maintenance_columns.py
+++ b/scripts/add_machine_maintenance_columns.py
@@ -1,0 +1,35 @@
+import os
+from sqlalchemy import create_engine, text
+
+DATABASE_URL = os.getenv('DATABASE_URL')
+if not DATABASE_URL:
+    raise SystemExit('DATABASE_URL environment variable not set')
+
+
+def main():
+    engine = create_engine(DATABASE_URL)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "ALTER TABLE machine ADD COLUMN IF NOT EXISTS oil_interval_hours INTEGER DEFAULT 24;"
+            )
+        )
+        print("oil_interval_hours column added or already exists")
+
+        conn.execute(
+            text(
+                "ALTER TABLE machine ADD COLUMN IF NOT EXISTS lube_interval_days INTEGER DEFAULT 7;"
+            )
+        )
+        print("lube_interval_days column added or already exists")
+
+        conn.execute(
+            text(
+                "ALTER TABLE machine ADD COLUMN IF NOT EXISTS grease_interval_months INTEGER DEFAULT 3;"
+            )
+        )
+        print("grease_interval_months column added or already exists")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a database migration script for machine maintenance interval columns
- include brief README instructions about running the script after deployment

## Testing
- `python -m py_compile scripts/add_machine_maintenance_columns.py`

------
https://chatgpt.com/codex/tasks/task_e_68672231443c832690afc1ceded9463e