### PR TITLE
Implement email-based password reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Tokatap
+
+This application uses Flask. To enable password reset emails through Gmail, set the following environment variables:
+
+- `GMAIL_USER` – your Gmail address used to send emails.
+- `GMAIL_PASS` – the app password for the above account.
+
+The feature uses a timed token so reset links expire after one hour.

--- a/app/reset_utils.py
+++ b/app/reset_utils.py
@@ -1,0 +1,42 @@
+from flask import current_app
+from itsdangerous import URLSafeTimedSerializer
+import os
+import smtplib
+from email.message import EmailMessage
+
+
+def generate_reset_token(email: str) -> str:
+    """Generate a timed token for password resets."""
+    serializer = URLSafeTimedSerializer(current_app.config['SECRET_KEY'])
+    return serializer.dumps(email, salt='password-reset')
+
+
+def verify_reset_token(token: str, expiration: int = 3600) -> str | None:
+    """Return the email embedded in a reset token if valid, else None."""
+    serializer = URLSafeTimedSerializer(current_app.config['SECRET_KEY'])
+    try:
+        email = serializer.loads(token, salt='password-reset', max_age=expiration)
+    except Exception:
+        return None
+    return email
+
+
+def send_reset_email(to_email: str, reset_url: str) -> None:
+    """Send password reset email via Gmail SMTP."""
+    user = os.getenv('GMAIL_USER')
+    password = os.getenv('GMAIL_PASS')
+    if not user or not password:
+        raise RuntimeError('GMAIL_USER and GMAIL_PASS must be set')
+
+    msg = EmailMessage()
+    msg['Subject'] = 'Tokatap Password Reset'
+    msg['From'] = user
+    msg['To'] = to_email
+    msg.set_content(
+        f'Click the link below to reset your password:\n{reset_url}\n\n'
+        'If you did not request a reset, please ignore this email.'
+    )
+
+    with smtplib.SMTP_SSL('smtp.gmail.com', 465) as smtp:
+        smtp.login(user, password)
+        smtp.send_message(msg)

--- a/app/templates/forgot_password.html
+++ b/app/templates/forgot_password.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Tokatap - Forgot Password</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gradient-to-br from-blue-100 to-white min-h-screen p-4">
+  <div class="bg-white/30 backdrop-blur-xl border border-white/20 rounded-2xl shadow-xl w-full max-w-sm mx-auto mt-10 text-center">
+    <img src="{{ url_for('static', filename='logo/logo.svg') }}" alt="Logo" class="w-20 h-auto mx-auto mt-4 object-contain">
+    <h2 class="text-2xl font-semibold text-slate-800 mt-2">Forgot Password</h2>
+    <p class="text-sm text-slate-600 mb-6">Enter your email to receive a reset link.</p>
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% for category, message in messages %}
+        <div class="text-sm text-red-600 mb-4 text-center">{{ message }}</div>
+      {% endfor %}
+    {% endwith %}
+
+    <form method="POST" class="space-y-4 text-left px-4">
+      <div>
+        <label class="block text-sm font-medium text-slate-600 mb-1">Email</label>
+        <input type="email" name="email" required placeholder="you@example.com" class="w-full px-4 py-2 rounded-xl bg-white/50 border border-white/20 backdrop-blur-md text-slate-800 shadow-inner placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-400">
+      </div>
+      <button type="submit" class="w-full py-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl shadow-lg transition-all duration-300">Send Reset Link</button>
+    </form>
+
+    <div class="text-sm text-slate-600 mt-6 mb-6">
+      <a href="{{ url_for('routes.user_login') }}" class="text-blue-600 hover:underline">← Back to login</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -107,6 +107,7 @@
     <!-- Links -->
     <div class="mt-6 text-sm text-slate-600">
       <p>New user? <a href="{{ url_for('routes.user_signup') }}" class="text-blue-600 hover:underline">Sign up here</a></p>
+      <p class="mt-2"><a href="{{ url_for('routes.forgot_password') }}" class="text-blue-600 hover:underline">Forgot Password?</a></p>
       <p class="mt-2"><a href="{{ url_for('routes.home') }}" class="text-blue-600 hover:underline">← Back to Home</a></p>
     </div>
 

--- a/app/templates/reset_password.html
+++ b/app/templates/reset_password.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Tokatap - Reset Password</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gradient-to-br from-blue-100 to-white min-h-screen p-4">
+  <div class="bg-white/30 backdrop-blur-xl border border-white/20 rounded-2xl shadow-xl w-full max-w-sm mx-auto mt-10 text-center">
+    <img src="{{ url_for('static', filename='logo/logo.svg') }}" alt="Logo" class="w-20 h-auto mx-auto mt-4 object-contain">
+    <h2 class="text-2xl font-semibold text-slate-800 mt-2">Reset Password</h2>
+    <p class="text-sm text-slate-600 mb-6">Enter a new password for your account.</p>
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% for category, message in messages %}
+        <div class="text-sm text-red-600 mb-4 text-center">{{ message }}</div>
+      {% endfor %}
+    {% endwith %}
+
+    <form method="POST" class="space-y-4 text-left px-4">
+      <div>
+        <label class="block text-sm font-medium text-slate-600 mb-1">New Password</label>
+        <input type="password" name="password" required placeholder="••••••••" class="w-full px-4 py-2 rounded-xl bg-white/50 border border-white/20 backdrop-blur-md text-slate-800 shadow-inner placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-400">
+      </div>
+      <button type="submit" class="w-full py-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl shadow-lg transition-all duration-300">Reset Password</button>
+    </form>
+
+    <div class="text-sm text-slate-600 mt-6 mb-6">
+      <a href="{{ url_for('routes.user_login') }}" class="text-blue-600 hover:underline">← Back to login</a>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Gmail-powered reset utilities
- provide views for requesting and setting new passwords
- link password reset from login
- document Gmail environment setup

## Testing
- `python -m py_compile app/routes.py app/reset_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68689bd772048326a7c7ad2d83abb41b