### PR TITLE
Add security question reset flow

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -16,6 +16,9 @@ class User(UserMixin, db.Model):
     company_name = db.Column(db.String(100))
     mobile = db.Column(db.String(20))
 
+    security_question = db.Column(db.String(255))
+    security_answer = db.Column(db.String(255))
+
     default_machine_name = db.Column(db.String(100))
     default_machine_location = db.Column(db.String(100))
 
@@ -134,3 +137,15 @@ class SubUserAction(db.Model):
     action_type = db.Column(db.String(20))     # "oiling", "lube", "service"
     status = db.Column(db.String(20))          # "done", "pending", "completed"
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+# -------------------------
+# 🔑 PASSWORD RESET TOKENS
+# -------------------------
+class PasswordResetToken(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    token = db.Column(db.String(64), unique=True, nullable=False)
+    expires_at = db.Column(db.DateTime, nullable=False)
+    used = db.Column(db.Boolean, default=False)
+

--- a/app/templates/forgot_password_email.html
+++ b/app/templates/forgot_password_email.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Forgot Password</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gradient-to-br from-blue-100 to-white min-h-screen p-4 flex items-center justify-center">
+  <div class="bg-white/30 backdrop-blur-xl border border-white/20 rounded-2xl shadow-xl w-full max-w-md p-6 space-y-4">
+    <h2 class="text-xl font-semibold text-center">Forgot Password</h2>
+    <p class="text-sm text-center text-slate-600">Email-based password reset is coming soon — for now, use the security question method.</p>
+    <p class="text-xs text-center text-slate-600">If you do not remember your security answer, contact <a href="mailto:tokatap.com@gmail.com" class="text-blue-600 hover:underline">tokatap.com@gmail.com</a>.</p>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% for category, message in messages %}
+        <div class="text-sm text-red-600 text-center">{{ message }}</div>
+      {% endfor %}
+    {% endwith %}
+    <form method="POST" class="space-y-4">
+      <input type="hidden" name="step" value="email">
+      <div>
+        <label class="block text-sm font-medium mb-1">Email</label>
+        <input type="email" name="email" required class="w-full px-4 py-2 rounded-xl bg-white/50 border border-white/20 shadow-inner">
+      </div>
+      <button type="submit" class="w-full py-2 bg-blue-600 text-white font-semibold rounded-xl shadow hover:bg-blue-700">Continue</button>
+    </form>
+    <div class="text-center text-sm">
+      <a href="{{ url_for('routes.user_login') }}" class="text-blue-600 hover:underline">Back to Login</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/app/templates/forgot_password_question.html
+++ b/app/templates/forgot_password_question.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Security Question</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gradient-to-br from-blue-100 to-white min-h-screen p-4 flex items-center justify-center">
+  <div class="bg-white/30 backdrop-blur-xl border border-white/20 rounded-2xl shadow-xl w-full max-w-md p-6 space-y-4">
+    <h2 class="text-xl font-semibold text-center">Security Question</h2>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% for category, message in messages %}
+        <div class="text-sm text-red-600 text-center">{{ message }}</div>
+      {% endfor %}
+    {% endwith %}
+    <form method="POST" class="space-y-4">
+      <input type="hidden" name="step" value="question">
+      <input type="hidden" name="user_id" value="{{ user_id }}">
+      <p class="text-sm text-center">{{ question }}</p>
+      <div>
+        <label class="block text-sm font-medium mb-1">Your Answer</label>
+        <input type="text" name="answer" required class="w-full px-4 py-2 rounded-xl bg-white/50 border border-white/20 shadow-inner">
+      </div>
+      <button type="submit" class="w-full py-2 bg-blue-600 text-white font-semibold rounded-xl shadow hover:bg-blue-700">Submit</button>
+    </form>
+  </div>
+</body>
+</html>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -95,6 +95,9 @@
         <label class="block text-sm font-medium text-slate-600 mb-1">Password</label>
         <input type="password" name="password" required placeholder="••••••••"
                class="w-full px-4 py-2 rounded-xl bg-white/50 border border-white/20 shadow-inner text-slate-800 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-400">
+        <div class="text-right mt-1">
+          <a href="{{ url_for('routes.forgot_password') }}" class="text-xs text-blue-600 hover:underline">Forgot Password?</a>
+        </div>
       </div>
 
       <button type="submit"

--- a/app/templates/reset_password.html
+++ b/app/templates/reset_password.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Reset Password</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gradient-to-br from-blue-100 to-white min-h-screen p-4 flex items-center justify-center">
+  <div class="bg-white/30 backdrop-blur-xl border border-white/20 rounded-2xl shadow-xl w-full max-w-md p-6 space-y-4">
+    <h2 class="text-xl font-semibold text-center">Set New Password</h2>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% for category, message in messages %}
+        <div class="text-sm text-red-600 text-center">{{ message }}</div>
+      {% endfor %}
+    {% endwith %}
+    <form method="POST" class="space-y-4">
+      <div>
+        <label class="block text-sm font-medium mb-1">New Password</label>
+        <input type="password" name="password" required class="w-full px-4 py-2 rounded-xl bg-white/50 border border-white/20 shadow-inner">
+      </div>
+      <button type="submit" class="w-full py-2 bg-blue-600 text-white font-semibold rounded-xl shadow hover:bg-blue-700">Reset Password</button>
+    </form>
+  </div>
+</body>
+</html>

--- a/app/templates/show_reset_link.html
+++ b/app/templates/show_reset_link.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Reset Link</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gradient-to-br from-blue-100 to-white min-h-screen p-4 flex items-center justify-center">
+  <div class="bg-white/30 backdrop-blur-xl border border-white/20 rounded-2xl shadow-xl w-full max-w-md p-6 space-y-4 text-center">
+    <h2 class="text-xl font-semibold">Password Reset Link</h2>
+    <p class="text-sm">Copy or open the link below within 10 minutes.</p>
+    <input id="resetLink" type="text" readonly value="{{ reset_link }}" class="w-full px-4 py-2 rounded-xl bg-white/50 border border-white/20 shadow-inner">
+    <button onclick="copyLink()" class="mt-2 px-4 py-2 bg-blue-600 text-white rounded-xl hover:bg-blue-700">Copy Link</button>
+    <p class="mt-4"><a href="{{ reset_link }}" target="_blank" class="text-blue-600 hover:underline">Open Reset Page</a></p>
+  </div>
+  <script>
+    function copyLink() {
+      const input = document.getElementById('resetLink');
+      input.select();
+      document.execCommand('copy');
+    }
+  </script>
+</body>
+</html>

--- a/app/templates/signup.html
+++ b/app/templates/signup.html
@@ -54,6 +54,18 @@
                class="w-full px-4 py-2 rounded-xl bg-white/50 border border-white/20 backdrop-blur-md text-slate-800 shadow-inner placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-400">
       </div>
 
+      <div>
+        <label class="block text-sm font-medium text-slate-600 mb-1">Security Question</label>
+        <input type="text" name="security_question" required placeholder="e.g. Your first pet's name"
+               class="w-full px-4 py-2 rounded-xl bg-white/50 border border-white/20 backdrop-blur-md text-slate-800 shadow-inner placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-400">
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-slate-600 mb-1">Security Answer</label>
+        <input type="text" name="security_answer" required placeholder="Answer"
+               class="w-full px-4 py-2 rounded-xl bg-white/50 border border-white/20 backdrop-blur-md text-slate-800 shadow-inner placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-400">
+      </div>
+
       <button type="submit"
               class="w-full py-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl shadow-lg transition-all duration-300">
         Sign Up

--- a/app/templates/user_settings.html
+++ b/app/templates/user_settings.html
@@ -109,6 +109,17 @@
               </button>
             </div>
           </div>
+
+          <div>
+            <label class="block text-sm mb-1">Security Question</label>
+            <input type="text" name="security_question" value="{{ current_user.security_question or '' }}"
+                   class="w-full px-4 py-2 rounded-xl bg-white/60 border border-white/30 shadow-inner">
+          </div>
+          <div>
+            <label class="block text-sm mb-1">Security Answer</label>
+            <input type="text" name="security_answer" value="{{ current_user.security_answer or '' }}"
+                   class="w-full px-4 py-2 rounded-xl bg-white/60 border border-white/30 shadow-inner">
+          </div>
         </div>
         <div class="text-right mt-4">
           <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl py-2 px-4 shadow">Save Profile</button>


### PR DESCRIPTION
## Summary
- support security questions in signup and profile settings
- add password reset token model
- implement forgotten password workflow with security question
- add password reset templates and link

## Testing
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6868ac35437c8326a4b40a9fb5560116