### PR TITLE
Add security question dropdown

### DIFF
--- a/app/templates/signup.html
+++ b/app/templates/signup.html
@@ -56,8 +56,20 @@
 
       <div>
         <label class="block text-sm font-medium text-slate-600 mb-1">Security Question</label>
-        <input type="text" name="security_question" required placeholder="e.g. Your first pet's name"
-               class="w-full px-4 py-2 rounded-xl bg-white/50 border border-white/20 backdrop-blur-md text-slate-800 shadow-inner placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-400">
+        <select name="security_question" required
+                class="w-full px-4 py-2 rounded-xl bg-white/50 border border-white/20 backdrop-blur-md text-slate-800 shadow-inner focus:outline-none focus:ring-2 focus:ring-blue-400">
+          <option value="" disabled selected>Select a question</option>
+          <option value="What was your childhood nickname?">What was your childhood nickname?</option>
+          <option value="What is the name of your favorite childhood friend?">What is the name of your favorite childhood friend?</option>
+          <option value="In what city were you born?">In what city were you born?</option>
+          <option value="What was the make of your first car?">What was the make of your first car?</option>
+          <option value="What is your mother's maiden name?">What is your mother's maiden name?</option>
+          <option value="What was the name of your elementary school?">What was the name of your elementary school?</option>
+          <option value="What is the name of the street you grew up on?">What is the name of the street you grew up on?</option>
+          <option value="What was your first job?">What was your first job?</option>
+          <option value="What is your favorite food?">What is your favorite food?</option>
+          <option value="What is your favorite movie?">What is your favorite movie?</option>
+        </select>
       </div>
 
       <div>


### PR DESCRIPTION
## Summary
- use a `<select>` dropdown for predefined security questions on the signup page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868b5f8223883268e113a0b38e453f3