### PR TITLE
Add security question dropdown

### DIFF
--- a/app/templates/signup.html
+++ b/app/templates/signup.html
@@ -56,8 +56,20 @@
 
       <div>
         <label class="block text-sm font-medium text-slate-600 mb-1">Security Question</label>
-        <input type="text" name="security_question" required placeholder="e.g. Your first pet's name"
-               class="w-full px-4 py-2 rounded-xl bg-white/50 border border-white/20 backdrop-blur-md text-slate-800 shadow-inner placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-400">
+        <select name="security_question" required
+                class="w-full px-4 py-2 rounded-xl bg-white/50 border border-white/20 backdrop-blur-md text-slate-800 shadow-inner focus:outline-none focus:ring-2 focus:ring-blue-400">
+          <option value="" disabled selected>Select a question</option>
+          <option value="What was your childhood nickname?">What was your childhood nickname?</option>
+          <option value="What is the name of your favorite childhood friend?">What is the name of your favorite childhood friend?</option>
+          <option value="In what city were you born?">In what city were you born?</option>
+          <option value="What was the make of your first car?">What was the make of your first car?</option>
+          <option value="What is your mother's maiden name?">What is your mother's maiden name?</option>
+          <option value="What was the name of your elementary school?">What was the name of your elementary school?</option>
+          <option value="What is the name of the street you grew up on?">What is the name of the street you grew up on?</option>
+          <option value="What was your first job?">What was your first job?</option>
+          <option value="What is your favorite food?">What is your favorite food?</option>
+          <option value="What is your favorite movie?">What is your favorite movie?</option>
+        </select>
       </div>
 
       <div>

--- a/app/templates/user_settings.html
+++ b/app/templates/user_settings.html
@@ -112,8 +112,20 @@
 
           <div>
             <label class="block text-sm mb-1">Security Question</label>
-            <input type="text" name="security_question" value="{{ current_user.security_question or '' }}"
-                   class="w-full px-4 py-2 rounded-xl bg-white/60 border border-white/30 shadow-inner">
+            <select name="security_question" required
+                    class="w-full px-4 py-2 rounded-xl bg-white/60 border border-white/30 shadow-inner">
+              <option value="" disabled {% if not current_user.security_question %}selected{% endif %}>Select a question</option>
+              <option value="What was your childhood nickname?" {% if current_user.security_question == 'What was your childhood nickname?' %}selected{% endif %}>What was your childhood nickname?</option>
+              <option value="What is the name of your favorite childhood friend?" {% if current_user.security_question == 'What is the name of your favorite childhood friend?' %}selected{% endif %}>What is the name of your favorite childhood friend?</option>
+              <option value="In what city were you born?" {% if current_user.security_question == 'In what city were you born?' %}selected{% endif %}>In what city were you born?</option>
+              <option value="What was the make of your first car?" {% if current_user.security_question == 'What was the make of your first car?' %}selected{% endif %}>What was the make of your first car?</option>
+              <option value="What is your mother's maiden name?" {% if current_user.security_question == "What is your mother's maiden name?" %}selected{% endif %}>What is your mother's maiden name?</option>
+              <option value="What was the name of your elementary school?" {% if current_user.security_question == 'What was the name of your elementary school?' %}selected{% endif %}>What was the name of your elementary school?</option>
+              <option value="What is the name of the street you grew up on?" {% if current_user.security_question == 'What is the name of the street you grew up on?' %}selected{% endif %}>What is the name of the street you grew up on?</option>
+              <option value="What was your first job?" {% if current_user.security_question == 'What was your first job?' %}selected{% endif %}>What was your first job?</option>
+              <option value="What is your favorite food?" {% if current_user.security_question == 'What is your favorite food?' %}selected{% endif %}>What is your favorite food?</option>
+              <option value="What is your favorite movie?" {% if current_user.security_question == 'What is your favorite movie?' %}selected{% endif %}>What is your favorite movie?</option>
+            </select>
           </div>
           <div>
             <label class="block text-sm mb-1">Security Answer</label>


### PR DESCRIPTION
## Summary
- use a `<select>` dropdown in user settings for predefined security questions just like on the signup page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868b5f8223883268e113a0b38e453f3