### PR TITLE
Fix back link on service log page

### DIFF
--- a/app/templates/service_options.html
+++ b/app/templates/service_options.html
@@ -37,7 +37,7 @@
 
     <div class="space-y-3">
       <!-- Log Service Part -->
-      <a href="{{ url_for('routes.sub_tag_service_log', sub_tag_id=service_tag.id) }}" class="flex items-center bg-white/60 hover:bg-blue-100 rounded-xl shadow p-4 transition border border-blue-400 hover:border-blue-600 text-left">
+      <a href="{{ url_for('routes.sub_tag_service_log', sub_tag_id=service_tag.id, back=request.url) }}" class="flex items-center bg-white/60 hover:bg-blue-100 rounded-xl shadow p-4 transition border border-blue-400 hover:border-blue-600 text-left">
         <img src="{{ url_for('static', filename='emb assets/setting.png') }}" alt="Service" class="h-8 sm:h-10 mr-4">
         <span class="flex flex-col items-start">
           <span class="text-blue-700 font-semibold text-base">Log Service Part</span>

--- a/app/templates/sub_service_log.html
+++ b/app/templates/sub_service_log.html
@@ -68,6 +68,7 @@
         Log Repaired Part
       </button>
       <form id="logForm" method="POST" class="expand-form collapsed space-y-4 bg-white/80 border border-white/30 rounded-xl mx-1 sm:mx-2 mt-0 px-4 py-2">
+        <input type="hidden" name="back_url" value="{{ back_url }}">
         <div>
           <label class="block text-sm font-medium text-slate-700 mb-1">Part Belongs To</label>
           <select name="belongs_to" required


### PR DESCRIPTION
## Summary
- preserve the referring page when opening and submitting the service log form
- include hidden field for back link
- pass the current page URL from service options

## Testing
- `python -m py_compile app/routes.py`

------
https://chatgpt.com/codex/tasks/task_e_6871df8c13dc832692dbb4c3da3a36fc