### PR TITLE
Add QR download tab with PDF export

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import IntegrityError
 import io
 import zipfile
 import requests
+from PIL import Image
 import random
 import string
 
@@ -856,6 +857,66 @@ def download_qr(qr_id):
         mimetype="image/png",
         as_attachment=True,
         download_name=f"{qr.qr_type}.png"
+    )
+
+@routes.route("/download-all-qrs")
+@login_required
+def download_all_qrs():
+    """Generate a PDF with all QR codes belonging to the current user."""
+    batches = QRBatch.query.filter_by(owner_id=current_user.id).all()
+    image_urls = []
+    for batch in batches:
+        codes = QRCode.query.filter_by(batch_id=batch.id).order_by(QRCode.qr_type).all()
+        image_urls.extend([c.image_url for c in codes])
+
+    if not image_urls:
+        flash("No QR codes found for your machines.", "danger")
+        return redirect(url_for("routes.user_settings", tab="download"))
+
+    images = []
+    for url in image_urls:
+        try:
+            resp = requests.get(url)
+            img = Image.open(io.BytesIO(resp.content)).convert("RGB")
+            images.append(img)
+        except Exception:
+            continue
+
+    if not images:
+        flash("Failed to retrieve QR images.", "danger")
+        return redirect(url_for("routes.user_settings", tab="download"))
+
+    A4_WIDTH, A4_HEIGHT = 2480, 3508
+    QR_W, QR_H = 800, 1200
+    COLS, ROWS = 2, 3
+    x_space = (A4_WIDTH - (QR_W * COLS)) // (COLS + 1)
+    y_space = (A4_HEIGHT - (QR_H * ROWS)) // (ROWS + 1)
+
+    pages = []
+    canvas = Image.new("RGB", (A4_WIDTH, A4_HEIGHT), "white")
+    idx = 0
+    for img in images:
+        resized = img.resize((QR_W, QR_H))
+        x = x_space + (idx % COLS) * (QR_W + x_space)
+        y = y_space + (idx // COLS) * (QR_H + y_space)
+        canvas.paste(resized, (x, y))
+        idx += 1
+        if idx == COLS * ROWS:
+            pages.append(canvas)
+            canvas = Image.new("RGB", (A4_WIDTH, A4_HEIGHT), "white")
+            idx = 0
+    if idx > 0:
+        pages.append(canvas)
+
+    buffer = io.BytesIO()
+    pages[0].save(buffer, format="PDF", save_all=True, append_images=pages[1:])
+    buffer.seek(0)
+
+    return send_file(
+        buffer,
+        mimetype="application/pdf",
+        as_attachment=True,
+        download_name="qr_codes.pdf",
     )
 
 

--- a/app/templates/user_settings.html
+++ b/app/templates/user_settings.html
@@ -53,6 +53,10 @@
               class="py-2 px-4 border-b-2 font-medium text-sm text-gray-500 hover:text-blue-700">
         🛠️ Machines
       </button>
+      <button id="tab-download" data-tab onclick="showTab('download')"
+              class="py-2 px-4 border-b-2 font-medium text-sm text-gray-500 hover:text-blue-700">
+        📥 Download QRs
+      </button>
     </div>
 
     <!-- Profile Form -->
@@ -176,7 +180,19 @@
           <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl py-2 px-4 shadow text-sm">Save</button>
         </div>
       </form>
-      {% endfor %}
+  {% endfor %}
+    </div>
+    <!-- Download Section -->
+    <div id="section-download" data-section class="hidden">
+      <div class="bg-white/30 backdrop-blur-md border border-white/20 p-5 rounded-xl space-y-4 shadow">
+        <h2 class="text-lg font-semibold mb-2">📥 Download QR Codes</h2>
+        <ul class="list-disc list-inside">
+          {% for machine in machines %}
+          <li>{{ machine.name }}</li>
+          {% endfor %}
+        </ul>
+        <a href="{{ url_for('routes.download_all_qrs') }}" class="bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl py-2 px-4 shadow inline-block">Download PDF</a>
+      </div>
     </div>
 
     <!-- Machines Actions outside main form -->


### PR DESCRIPTION
## Summary
- add PDF generation route to download all QR codes in bulk
- import PIL Image for PDF creation
- extend user settings with a new **Download QRs** tab
- list machines and link to download PDF

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871eb4653bc8326a6bd30dee20b113c