### PR TITLE
Add QR download tab with PDF export

### DIFF
--- a/app/templates/user_settings.html
+++ b/app/templates/user_settings.html
@@ -53,6 +53,10 @@
               class="py-2 px-4 border-b-2 font-medium text-sm text-gray-500 hover:text-blue-700">
         🛠️ Machines
       </button>
+      <button id="tab-download" data-tab onclick="showTab('download')"
+              class="py-2 px-4 border-b-2 font-medium text-sm text-gray-500 hover:text-blue-700">
+        📥 Download QRs
+      </button>
     </div>
 
     <!-- Profile Form -->
@@ -176,7 +180,22 @@
           <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl py-2 px-4 shadow text-sm">Save</button>
         </div>
       </form>
-      {% endfor %}
+  {% endfor %}
+    </div>
+    <!-- Download Section -->
+    <div id="section-download" data-section class="hidden">
+      <div class="bg-white/30 backdrop-blur-md border border-white/20 p-5 rounded-xl space-y-4 shadow">
+        <h2 class="text-lg font-semibold mb-2">📥 Download QR Codes</h2>
+        <ul class="space-y-2">
+          {% for machine in machines %}
+          <li class="flex justify-between items-center bg-white/50 rounded-lg px-4 py-2">
+            <span class="font-medium">{{ machine.name }}</span>
+            <a href="{{ url_for('routes.download_machine_qrs', machine_id=machine.id) }}" class="text-sm bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded-md shadow">Download</a>
+          </li>
+          {% endfor %}
+        </ul>
+        <a href="{{ url_for('routes.download_all_qrs') }}" class="mt-3 inline-block bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl py-2 px-4 shadow">Download All</a>
+      </div>
     </div>
 
     <!-- Machines Actions outside main form -->


### PR DESCRIPTION
## Summary
- add PDF generation route to download QR codes by machine
- add utility to build prettier QR PDF pages with machine/name labels
- list machines with individual download buttons

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871eb4653bc8326a6bd30dee20b113c