### PR TITLE
Add setup guide and FAQ pages

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -41,6 +41,14 @@ routes = Blueprint("routes", __name__)
 @routes.route("/")
 def home():
     return render_template("index.html")
+
+@routes.route("/setup-guide")
+def setup_guide_page():
+    return render_template("setup_guide.html")
+
+@routes.route("/faq")
+def faq_page():
+    return render_template("faq.html")
 @routes.route("/scan/master/<int:batch_id>")
 def scan_master(batch_id):
     # If a sub-user is logged in, go to sub-user dashboard

--- a/app/templates/faq.html
+++ b/app/templates/faq.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Tokatap – FAQ</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gradient-to-br from-blue-100 via-white to-blue-200 min-h-screen flex flex-col">
+    <main class="flex-grow max-w-4xl mx-auto p-6">
+        <h1 class="text-3xl sm:text-4xl font-bold text-blue-900 mb-6 text-center">Tokatap FAQ</h1>
+        <dl class="space-y-6 text-slate-700">
+            <div>
+                <dt class="font-semibold">What is Tokatap?</dt>
+                <dd class="mt-1 text-sm">Tokatap is a digital logbook system for machine maintenance. Each machine is paired with QR codes so you can quickly log services, needle changes, and repairs.</dd>
+            </div>
+            <div>
+                <dt class="font-semibold">How do I get started?</dt>
+                <dd class="mt-1 text-sm">Sign up for a main user account, claim or generate a QR batch, attach the codes to your machines, and add machine details.</dd>
+            </div>
+            <div>
+                <dt class="font-semibold">What is a QR batch?</dt>
+                <dd class="mt-1 text-sm">A batch contains one MASTER tag, one SERVICE tag, and eight HEAD tags to track maintenance for each machine and head.</dd>
+            </div>
+            <div>
+                <dt class="font-semibold">Can I add more than one machine?</dt>
+                <dd class="mt-1 text-sm">Yes. Generate a new QR batch from Settings whenever you want to register another machine.</dd>
+            </div>
+            <div>
+                <dt class="font-semibold">How do sub‑users log their work?</dt>
+                <dd class="mt-1 text-sm">Sub-users log in with their unique code, scan the SERVICE or HEAD tags, and their actions are recorded in your machine history.</dd>
+            </div>
+            <div>
+                <dt class="font-semibold">What happens if I lose a QR code?</dt>
+                <dd class="mt-1 text-sm">Re-download the codes from Settings → Download QRs and reprint them at any time.</dd>
+            </div>
+            <div>
+                <dt class="font-semibold">How do service reminders work?</dt>
+                <dd class="mt-1 text-sm">Tokatap tracks the last time maintenance was logged and shows upcoming or overdue tasks on your dashboard.</dd>
+            </div>
+            <div>
+                <dt class="font-semibold">How do I log a repaired part or warranty?</dt>
+                <dd class="mt-1 text-sm">Scan the relevant tag and select Log Service Part to record the part name, description, and optional warranty date.</dd>
+            </div>
+            <div>
+                <dt class="font-semibold">What if a machine needs urgent repair?</dt>
+                <dd class="mt-1 text-sm">Raise a service request from the SERVICE or HEAD tag and it will appear on your dashboard until resolved.</dd>
+            </div>
+            <div>
+                <dt class="font-semibold">How secure is my account?</dt>
+                <dd class="mt-1 text-sm">Your password and security question protect your account. Use Forgot Password if you need to reset it.</dd>
+            </div>
+            <div>
+                <dt class="font-semibold">Is there a mobile app?</dt>
+                <dd class="mt-1 text-sm">Tokatap works directly in your web browser—scanning a QR code brings you to the right page without any installation.</dd>
+            </div>
+            <div>
+                <dt class="font-semibold">What does the admin login do?</dt>
+                <dd class="mt-1 text-sm">The admin area is used internally for managing QR batches. Regular customers don't need admin access.</dd>
+            </div>
+        </dl>
+    </main>
+    <footer class="bg-blue-950 text-blue-100 py-7 mt-12">
+        <div class="max-w-4xl mx-auto flex flex-col items-center gap-1 text-sm">
+            <div><span class="font-bold">Tokatap</span> &copy; 2025. All rights reserved.</div>
+            <div>Built with ❤️ by JD.</div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/app/templates/setup_guide.html
+++ b/app/templates/setup_guide.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Tokatap – Setup Guide</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gradient-to-br from-blue-100 via-white to-blue-200 min-h-screen flex flex-col">
+    <main class="flex-grow max-w-4xl mx-auto p-6">
+        <h1 class="text-3xl sm:text-4xl font-bold text-blue-900 mb-6 text-center">Tokatap Setup Guide</h1>
+        <ol class="list-decimal list-inside space-y-4 text-slate-700">
+            <li>
+                <strong>Sign Up</strong>
+                <ol class="list-decimal list-inside pl-5 mt-1 space-y-1 text-sm">
+                    <li>Visit the Tokatap home page and choose <em>"Try Tokatap Free"</em>.</li>
+                    <li>Complete the sign up form and log in with your new credentials.</li>
+                </ol>
+            </li>
+            <li>
+                <strong>Claim or Create Your Machine Batch</strong>
+                <ol class="list-decimal list-inside pl-5 mt-1 space-y-1 text-sm">
+                    <li>Scan the <em>MASTER</em> QR code that came with your machine.</li>
+                    <li>If you don't have QR codes yet, generate a batch from the <em>Machines</em> tab in Settings.</li>
+                    <li>Print or download your codes and attach them to the machine.</li>
+                </ol>
+            </li>
+            <li>
+                <strong>Add Machine Details</strong>
+                <ol class="list-decimal list-inside pl-5 mt-1 space-y-1 text-sm">
+                    <li>From the <em>Machines</em> tab, name your machine and set maintenance intervals.</li>
+                </ol>
+            </li>
+            <li>
+                <strong>Assign Sub‑Users (Optional)</strong>
+                <ol class="list-decimal list-inside pl-5 mt-1 space-y-1 text-sm">
+                    <li>Create a sub-user from your dashboard and share their unique code.</li>
+                    <li>Sub-users can only see and log actions for their assigned machine.</li>
+                </ol>
+            </li>
+            <li>
+                <strong>Daily Operation for Sub‑Users</strong>
+                <ol class="list-decimal list-inside pl-5 mt-1 space-y-1 text-sm">
+                    <li>Sub-users log in with their code on the Sub-User Login page.</li>
+                    <li>Scan the <em>SERVICE</em> tag to mark oiling or lubrication as done or raise service requests.</li>
+                </ol>
+            </li>
+            <li>
+                <strong>Logging Needle Changes and Repairs</strong>
+                <ol class="list-decimal list-inside pl-5 mt-1 space-y-1 text-sm">
+                    <li>Scan a <em>HEAD</em> tag to log needle changes.</li>
+                    <li>Log replaced parts using the <em>Log Service Part</em> option.</li>
+                </ol>
+            </li>
+            <li>
+                <strong>Monitoring Your Machines</strong>
+                <ol class="list-decimal list-inside pl-5 mt-1 space-y-1 text-sm">
+                    <li>The User Dashboard shows status summaries and service requests.</li>
+                    <li>Use Machine Dashboard for a detailed history.</li>
+                </ol>
+            </li>
+            <li>
+                <strong>Service Requests</strong>
+                <ol class="list-decimal list-inside pl-5 mt-1 space-y-1 text-sm">
+                    <li>Raise service requests from SERVICE or HEAD tags.</li>
+                    <li>Mark them as completed when resolved.</li>
+                </ol>
+            </li>
+            <li>
+                <strong>Password Recovery</strong>
+                <ol class="list-decimal list-inside pl-5 mt-1 space-y-1 text-sm">
+                    <li>Use <em>Forgot Password</em> on the login page and answer your security question.</li>
+                </ol>
+            </li>
+            <li>
+                <strong>Logging Out</strong>
+                <ol class="list-decimal list-inside pl-5 mt-1 space-y-1 text-sm">
+                    <li>Use the <em>Logout</em> option in your dashboard when finished.</li>
+                </ol>
+            </li>
+        </ol>
+    </main>
+    <footer class="bg-blue-950 text-blue-100 py-7 mt-12">
+        <div class="max-w-4xl mx-auto flex flex-col items-center gap-1 text-sm">
+            <div><span class="font-bold">Tokatap</span> &copy; 2025. All rights reserved.</div>
+            <div>Built with ❤️ by JD.</div>
+        </div>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `setup_guide.html` and `faq.html` with instructions and new footer
- expose new `/setup-guide` and `/faq` routes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68728422f20c83268c3c0808b004a406