### PR TITLE
Fix back navigation on help pages

### DIFF
--- a/app/templates/faq.html
+++ b/app/templates/faq.html
@@ -8,7 +8,7 @@
 </head>
 <body class="bg-gradient-to-br from-blue-100 via-white to-blue-200 min-h-screen flex flex-col">
     <main class="flex-grow max-w-4xl mx-auto p-6">
-        <a href="{{ url_for('routes.home') }}" class="inline-block mb-4 text-blue-600 hover:underline">&larr; Back to Home</a>
+        <a href="javascript:history.back()" class="inline-block mb-4 text-blue-600 hover:underline">&larr; Back</a>
         <h1 class="text-3xl sm:text-4xl font-bold text-blue-900 mb-6 text-center">Tokatap FAQ</h1>
         <dl class="space-y-6 text-slate-700">
             <div>

--- a/app/templates/setup_guide.html
+++ b/app/templates/setup_guide.html
@@ -8,7 +8,7 @@
 </head>
 <body class="bg-gradient-to-br from-blue-100 via-white to-blue-200 min-h-screen flex flex-col">
     <main class="flex-grow max-w-4xl mx-auto p-6">
-        <a href="{{ url_for('routes.home') }}" class="inline-block mb-4 text-blue-600 hover:underline">&larr; Back to Home</a>
+        <a href="javascript:history.back()" class="inline-block mb-4 text-blue-600 hover:underline">&larr; Back</a>
         <h1 class="text-3xl sm:text-4xl font-bold text-blue-900 mb-6 text-center">Tokatap Setup Guide</h1>
         <ol class="list-decimal list-inside space-y-4 text-slate-700">
             <li>


### PR DESCRIPTION
## Summary
- use browser history for the back link on Setup Guide
- use browser history for the back link on FAQ

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68731ae827bc832690359542a19e68b3