### PR TITLE
Remove unused QR bulk download

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -868,14 +868,16 @@ def download_qr(qr_id):
 
 
 
-def _build_qr_page(qr_codes, title=None):
+def _build_qr_page(qr_codes, title=None, machine=None):
     """Return a PIL Image with QR codes arranged on an A4 page."""
     A4_WIDTH, A4_HEIGHT = 2480, 3508
-    QR_SIZE = 550
+    # Maintain same aspect ratio as admin QR images (~2:3)
+    QR_W = int(30 / 25.4 * 300)
+    QR_H = int(QR_W * 1.5)
     COLS, ROWS = 3, 4
-    top_margin = 180
-    x_space = (A4_WIDTH - (QR_SIZE * COLS)) // (COLS + 1)
-    y_space = (A4_HEIGHT - top_margin - (QR_SIZE * ROWS)) // (ROWS + 1)
+    top_margin = 250
+    x_space = (A4_WIDTH - (QR_W * COLS)) // (COLS + 1)
+    y_space = (A4_HEIGHT - top_margin - (QR_H * ROWS)) // (ROWS + 1)
 
     page = Image.new("RGB", (A4_WIDTH, A4_HEIGHT), "white")
     draw = ImageDraw.Draw(page)
@@ -886,23 +888,39 @@ def _build_qr_page(qr_codes, title=None):
         font_title = ImageFont.load_default()
         font_label = ImageFont.load_default()
 
+    if machine:
+        owner = machine.batch.owner
+        owner_name = owner.company_name or owner.name
+        subtitle = f"{machine.type} - {owner_name}" if machine.type else owner_name
+    else:
+        subtitle = None
+
     if title:
         bbox = draw.textbbox((0, 0), title, font=font_title)
         draw.text(((A4_WIDTH - bbox[2]) // 2, 60), title, font=font_title, fill="black")
+        if subtitle:
+            sbbox = draw.textbbox((0,0), subtitle, font=font_label)
+            draw.text(((A4_WIDTH - sbbox[2]) // 2, 60 + bbox[3] + 20), subtitle, font=font_label, fill="black")
 
     for idx, qr in enumerate(qr_codes):
         col = idx % COLS
         row = idx // COLS
-        x = x_space + col * (QR_SIZE + x_space)
-        y = top_margin + y_space + row * (QR_SIZE + y_space + 70)
+        x = x_space + col * (QR_W + x_space)
+        y = top_margin + y_space + row * (QR_H + y_space + 70)
         try:
             resp = requests.get(qr.image_url)
             img = Image.open(io.BytesIO(resp.content)).convert("RGB")
-            img = img.resize((QR_SIZE, QR_SIZE))
+            img = img.resize((QR_W, QR_H))
+            # draw light border to mimic admin card style
+            border_rect = [x - 10, y - 10, x + QR_W + 10, y + QR_H + 10]
+            draw.rectangle(border_rect, outline="gray", width=2)
             page.paste(img, (x, y))
-            label = qr.qr_type.upper()
+            if qr.qr_type.startswith("sub"):
+                label = f"HEAD {qr.qr_type[3:]}"
+            else:
+                label = qr.qr_type.upper()
             lbbox = draw.textbbox((0, 0), label, font=font_label)
-            draw.text((x + (QR_SIZE - lbbox[2]) // 2, y + QR_SIZE + 10), label, font=font_label, fill="black")
+            draw.text((x + (QR_W - lbbox[2]) // 2, y + QR_H + 10), label, font=font_label, fill="black")
         except Exception:
             continue
     return page
@@ -930,7 +948,7 @@ def download_machine_qrs(machine_id):
         flash("No QR codes found for this machine.", "danger")
         return redirect(url_for("routes.user_settings", tab="download"))
 
-    page = _build_qr_page(qr_codes, title=machine.name)
+    page = _build_qr_page(qr_codes, title=machine.name, machine=machine)
 
     buffer = io.BytesIO()
     page.save(buffer, format="PDF")
@@ -956,7 +974,7 @@ def download_all_qrs():
     for machine in machines:
         codes = QRCode.query.filter_by(batch_id=machine.batch_id).order_by(QRCode.qr_type).all()
         if codes:
-            pages.append(_build_qr_page(codes, title=machine.name))
+            pages.append(_build_qr_page(codes, title=machine.name, machine=machine))
 
     if not pages:
         flash("Failed to retrieve QR images.", "danger")

--- a/app/templates/user_settings.html
+++ b/app/templates/user_settings.html
@@ -197,10 +197,6 @@
       </li>
       {% endfor %}
     </ul>
-    <a href="{{ url_for('routes.download_all_qrs') }}"
-       class="mt-3 inline-block bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl py-2 px-4 shadow">
-      Download All
-    </a>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- remove "Download All" button from QR download section
- add machine information to QR PDFs and resize codes
- style user QR PDFs like admin view

## Testing
- `python -m compileall -q app`


------
https://chatgpt.com/codex/tasks/task_e_687322e5a0108326957058fc187b16b9