### PR TITLE
Add needle view toggle

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -186,7 +186,20 @@ def sub_tag_view(sub_tag_id):
         flash(f"Needle #{needle_number} updated successfully!", "success")
         return redirect(url_for("routes.sub_tag_view", sub_tag_id=sub_tag_id))
 
-    logs = NeedleChange.query.filter_by(sub_tag_id=sub_tag.id).order_by(NeedleChange.timestamp.desc()).all()
+    view_mode = request.args.get("view", "head")
+    selected_needle = request.args.get("needle_number", type=int)
+
+    if view_mode == "needle" and selected_needle:
+        logs = NeedleChange.query.filter_by(
+            batch_id=sub_tag.batch.id,
+            needle_number=selected_needle
+        ).order_by(NeedleChange.timestamp.desc()).all()
+    else:
+        logs = NeedleChange.query.filter_by(sub_tag_id=sub_tag.id).order_by(
+            NeedleChange.timestamp.desc()
+        ).all()
+        selected_needle = None
+
     last_change_dict = {}
     for log in logs:
         if log.needle_number not in last_change_dict:
@@ -205,7 +218,10 @@ def sub_tag_view(sub_tag_id):
         sub_tag=sub_tag,
         last_change_dict=last_change_dict,
         now=datetime.utcnow(),
-        back_url=back_url
+        back_url=back_url,
+        view_mode=view_mode,
+        selected_needle=selected_needle,
+        logs=logs,
     )
 
 @routes.route("/user/log/<type>/<int:machine_id>", methods=["POST"])

--- a/app/templates/sub_tag_view.html
+++ b/app/templates/sub_tag_view.html
@@ -55,6 +55,45 @@
       margin-left: auto;
       display: block;
     }
+    .toggle-container {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-top: 10px;
+      gap: 8px;
+    }
+    .switch {
+      position: relative;
+      display: inline-block;
+      width: 42px;
+      height: 24px;
+    }
+    .switch input { display:none; }
+    .slider {
+      position: absolute;
+      cursor: pointer;
+      top: 0; left: 0; right: 0; bottom: 0;
+      background-color: #ccc;
+      transition: .4s;
+      border-radius: 24px;
+    }
+    .slider:before {
+      position: absolute;
+      content: "";
+      height: 18px;
+      width: 18px;
+      left: 3px;
+      bottom: 3px;
+      background-color: white;
+      transition: .4s;
+      border-radius: 50%;
+    }
+    input:checked + .slider {
+      background-color: #0ea5e9;
+    }
+    input:checked + .slider:before {
+      transform: translateX(18px);
+    }
     .container {
       max-width: 480px;
       margin: 16px auto;
@@ -309,6 +348,15 @@
     <img src="{{ url_for('static', filename='logo/logo.svg') }}" alt="Logo" class="logo-right" />
   </div>
 
+  <div class="toggle-container">
+    <span>Head View</span>
+    <label class="switch">
+      <input type="checkbox" id="view-toggle" {% if view_mode == 'needle' %}checked{% endif %}>
+      <span class="slider"></span>
+    </label>
+    <span>Needle View</span>
+  </div>
+
   <div class="container">
     <!-- Header with just the number -->
     <h2>
@@ -319,6 +367,7 @@
         {{ sub_tag.tag_type }}
       {% endif %}
     </h2>
+    {% if view_mode == 'head' %}
     <form method="POST">
       <h3>Select Needle Number</h3>
       <div class="needle-grid">
@@ -369,6 +418,27 @@
         {% endfor %}
       </ul>
     </div>
+    {% else %}
+    <h3>Select Needle Number</h3>
+    <select id="needle-select" class="w-full px-3 py-2 rounded-xl bg-white/60 border border-white/30 shadow-inner mb-4">
+      {% set needle_count = sub_tag.batch.machine.needles_per_head if sub_tag.batch.machine else 15 %}
+      {% for i in range(1, needle_count + 1) %}
+        <option value="{{ i }}" {% if selected_needle == i %}selected{% endif %}>Needle {{ i }}</option>
+      {% endfor %}
+    </select>
+    <div class="log-box">
+      <div class="log-header">
+        <h3>Logs for Needle {{ selected_needle }}</h3>
+      </div>
+      <ul class="log-list expanded">
+        {% for log in logs %}
+          <li>Head {{ log.sub_tag.tag_type.replace('sub ', '') }} – Type {{ log.needle_type }} – {{ log.timestamp.strftime('%d %b %Y') }}</li>
+        {% else %}
+          <li>No logs for this needle.</li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
 
     <!-- Tips Legend Box -->
     <div class="legend-box">
@@ -406,6 +476,26 @@
       list.classList.toggle('collapsed');
       list.classList.toggle('expanded');
       toggle.classList.toggle('collapsed');
+    }
+
+    const viewToggle = document.getElementById('view-toggle');
+    if (viewToggle) {
+      viewToggle.addEventListener('change', () => {
+        if (viewToggle.checked) {
+          const sel = document.getElementById('needle-select');
+          const num = sel ? sel.value : 1;
+          window.location.href = '{{ url_for('routes.sub_tag_view', sub_tag_id=sub_tag.id) }}?view=needle&needle_number=' + num;
+        } else {
+          window.location.href = '{{ url_for('routes.sub_tag_view', sub_tag_id=sub_tag.id) }}';
+        }
+      });
+    }
+
+    const needleSelect = document.getElementById('needle-select');
+    if (needleSelect) {
+      needleSelect.addEventListener('change', () => {
+        window.location.href = '{{ url_for('routes.sub_tag_view', sub_tag_id=sub_tag.id) }}?view=needle&needle_number=' + needleSelect.value;
+      });
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add 'Needle View' mode to `sub_tag_view` route and template
- allow selecting a needle across all heads
- include a toggle switch and dropdown for switching views

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688d496066908326a05fbc7399fc0f87