### PR TITLE
Fix needle view header formatting

### DIFF
--- a/app/templates/sub_tag_view.html
+++ b/app/templates/sub_tag_view.html
@@ -389,8 +389,8 @@
     <!-- Header with just the number -->
     <h2>
       Head
-      {% if sub_tag.tag_type.startswith("sub ") %}
-        {{ sub_tag.tag_type.replace("sub ", "") }}
+      {% if sub_tag.tag_type.startswith('sub') %}
+        {{ sub_tag.tag_type.replace('sub', '').strip() }}
       {% else %}
         {{ sub_tag.tag_type }}
       {% endif %}


### PR DESCRIPTION
## Summary
- Remove `sub` prefix from needle change header to show only head number

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d74acfb808326a28d1f727633f326