### PR TITLE
Show head number on new line in needle view

### DIFF
--- a/app/templates/sub_tag_view.html
+++ b/app/templates/sub_tag_view.html
@@ -226,6 +226,7 @@
       font-size: 14px;
       font-weight: 600;
       margin-bottom: 4px;
+      text-align: center;
     }
     @keyframes selectPop {
       0% { transform: scale(1); }
@@ -388,7 +389,7 @@
   <div class="container">
     <!-- Header with just the number -->
     <h2>
-      Head
+      Head<br>
       {% if sub_tag.tag_type.startswith('sub') %}
         {{ sub_tag.tag_type.replace('sub', '').strip() }}
       {% else %}
@@ -461,7 +462,7 @@
           {% set log = last_change_dict.get(head.id) %}
           {% set is_stale = log and (now - log.timestamp).days > 10 %}
           <div class="head-item">
-            <div class="head-label">Head {{ head.tag_type.replace('sub', '') }}</div>
+            <div class="head-label">Head<br>{{ head.tag_type.replace('sub', '') }}</div>
             <div class="needle-shape {% if is_stale %}needle-stale{% endif %}" data-id="{{ head.id }}">
               {% if log %}
                 <div class="date">{{ log.timestamp.strftime('%d') }}<br>{{ log.timestamp.strftime('%b') }}</div>


### PR DESCRIPTION
## Summary
- Show head numbers on a second line so labels don't stretch horizontally
- Center-align head labels for consistent layout

## Testing
- `pytest`
- `flake8` *(missing: installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688d777687bc8326b21bc8db7ba64f56