### PR TITLE
Display head number inline on needle change page

### DIFF
--- a/app/templates/sub_tag_view.html
+++ b/app/templates/sub_tag_view.html
@@ -389,11 +389,10 @@
   <div class="container">
     <!-- Header with just the number -->
     <h2>
-      Head<br>
       {% if sub_tag.tag_type.startswith('sub') %}
-        {{ sub_tag.tag_type.replace('sub', '').strip() }}
+        Head {{ sub_tag.tag_type.replace('sub', '').strip() }}
       {% else %}
-        {{ sub_tag.tag_type }}
+        Head {{ sub_tag.tag_type }}
       {% endif %}
     </h2>
     {% if view_mode == 'head' %}


### PR DESCRIPTION
## Summary
- Show head number directly after "Head" in needle change page title

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d79e4ba308326930dfb2045e1084e