### PR TITLE
feat: apply iOS26 liquid glass theme

### DIFF
--- a/app/_backups_ios26/base.html.bak
+++ b/app/_backups_ios26/base.html.bak
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{% block title %}{% endblock %}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+  {% block head %}{% endblock %}
+</head>
+<body class="min-h-screen bg-gradient-to-br from-blue-100 to-white text-gray-800 flex flex-col">
+  <header class="bg-blue-950 text-white">
+    <div class="max-w-4xl mx-auto px-4 py-3 flex justify-between items-center">
+      <a href="{{ url_for('routes.home') }}" class="font-bold">Tokatap</a>
+      <nav class="space-x-4 text-sm">
+        <a href="{{ url_for('routes.user_login') }}" class="hover:underline">Login</a>
+        <a href="{{ url_for('routes.user_signup') }}" class="hover:underline">Sign Up</a>
+      </nav>
+    </div>
+  </header>
+  <main class="flex-1 max-w-4xl mx-auto w-full px-4 py-6">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        {% include '_flash.html' %}
+      {% endif %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+  </main>
+  <footer class="bg-blue-950 text-blue-100 py-6 text-center text-xs">
+    <div class="max-w-4xl mx-auto flex flex-col items-center gap-1">
+      <div><span class="font-bold">Tokatap</span> &copy; 2025. All rights reserved.</div>
+      <div class="flex gap-4 mt-1">
+        <a href="{{ url_for('routes.setup_guide_page') }}" class="hover:text-white">Setup Guide</a>
+        <a href="{{ url_for('routes.faq_page') }}" class="hover:text-white">FAQ</a>
+      </div>
+    </div>
+  </footer>
+  {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/app/_backups_ios26/styles.css.bak
+++ b/app/_backups_ios26/styles.css.bak
@@ -1,0 +1,63 @@
+/* Custom utilities and animations */
+.toast {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9999;
+  padding: 12px 24px;
+  background-color: #22c55e;
+  color: white;
+  font-weight: 500;
+  border-radius: 10px;
+  box-shadow: 0 5px 20px rgba(0,0,0,0.2);
+  opacity: 0;
+  transition: opacity 0.5s ease;
+}
+.toast.show { opacity: 1; }
+@keyframes float {
+  0%,100% { transform: translateY(0) translateX(0); }
+  50% { transform: translateY(-6px) translateX(6px); }
+}
+.mascot-float { animation: float 4s ease-in-out infinite; }
+@keyframes fadeUp {
+  0% { transform: translateY(20px); opacity: 0; }
+  100% { transform: translateY(0); opacity: 1; }
+}
+.logo-fade { animation: fadeUp 1.8s ease-out forwards; }
+.icon-side {
+  width: 2.2rem;
+  height: 2.2rem;
+  min-width: 2.2rem;
+  min-height: 2.2rem;
+  margin-right: 1rem;
+  color: #64748b;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.btn-card {
+  min-height: 72px;
+  padding-top: 0.8rem;
+  padding-bottom: 0.8rem;
+}
+.expand-form {
+  transition: max-height 0.3s cubic-bezier(.4,0,.2,1);
+  overflow: hidden;
+}
+.expand-form.collapsed {
+  max-height: 0;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}
+.expand-form.expanded {
+  max-height: 800px;
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+}
+@keyframes slide-in-right {
+  0% { opacity:0; transform: translateX(100%); }
+  100% { opacity:1; transform: translateX(0); }
+}
+.animate-slide-in-right { animation: slide-in-right 0.3s ease-out; }

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -61,3 +61,73 @@
   100% { opacity:1; transform: translateX(0); }
 }
 .animate-slide-in-right { animation: slide-in-right 0.3s ease-out; }
+/* ===== iOS 26 “Liquid Glass” theme — injected ===== */
+:root{
+  --lg-bg-1:#0b1220; --lg-bg-2:#0c1426;
+  --lg-accent:#4f8cff; --lg-accent-2:#a78bfa;
+  --lg-surface:rgba(255,255,255,.08); --lg-surface-strong:rgba(255,255,255,.14);
+  --lg-border:rgba(255,255,255,.18);
+  --lg-text:#e8ecf1; --lg-text-dim:#b6c0d0;
+  --lg-success:#22c55e; --lg-danger:#ef4444; --lg-warning:#f59e0b;
+  --r-xl:1.25rem; --r-2xl:1.75rem;
+  --sh1:0 4px 24px rgba(0,0,0,.2); --sh2:0 8px 36px rgba(0,0,0,.28);
+}
+
+/* Dynamic layered background */
+body.ios26-bg{
+  background:
+    radial-gradient(1200px 800px at 10% -10%, rgba(99,102,241,.25), transparent 60%),
+    radial-gradient(900px 600px at 100% 10%, rgba(79,140,255,.25), transparent 60%),
+    radial-gradient(1000px 700px at -10% 100%, rgba(111,231,255,.2), transparent 60%),
+    linear-gradient(180deg, var(--lg-bg-1), var(--lg-bg-2));
+  color:var(--lg-text);
+}
+
+/* Glass surfaces */
+.lg-glass{background:var(--lg-surface);backdrop-filter:blur(18px) saturate(120%);-webkit-backdrop-filter:blur(18px) saturate(120%);border:1px solid var(--lg-border);box-shadow:var(--sh1);border-radius:var(--r-xl);}
+.lg-glass-strong{background:var(--lg-surface-strong);backdrop-filter:blur(24px) saturate(140%);-webkit-backdrop-filter:blur(24px) saturate(140%);border:1px solid rgba(255,255,255,.22);box-shadow:var(--sh2);border-radius:var(--r-2xl);}
+.lg-card{padding:1rem 1.125rem;} .lg-card-lg{padding:1.25rem 1.5rem;}
+
+/* Bars */
+.lg-bar{background:linear-gradient(180deg, rgba(255,255,255,.12), rgba(255,255,255,.06));backdrop-filter:blur(16px) saturate(120%);-webkit-backdrop-filter:blur(16px) saturate(120%);border-bottom:1px solid var(--lg-border);box-shadow:0 2px 16px rgba(0,0,0,.25);}
+.lg-footer{background:linear-gradient(0deg, rgba(255,255,255,.10), rgba(255,255,255,.05));border-top:1px solid var(--lg-border);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);box-shadow:0 -2px 16px rgba(0,0,0,.20);}
+
+/* Type */
+.h1,.h2,.h3{letter-spacing:-.01em}.h1{font-size:clamp(1.8rem,2.6vw,2.4rem);font-weight:700}.h2{font-size:clamp(1.35rem,1.8vw,1.6rem);font-weight:650}.h3{font-size:clamp(1.1rem,1.4vw,1.25rem);font-weight:600}.text-dim{color:var(--lg-text-dim)}
+
+/* Buttons */
+.btn{display:inline-flex;align-items:center;gap:.5rem;padding:.6rem 1rem;border-radius:9999px;font-weight:600;border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg, rgba(255,255,255,.18), rgba(255,255,255,.06));backdrop-filter:blur(12px) saturate(120%);-webkit-backdrop-filter:blur(12px) saturate(120%);transition:transform .08s ease, box-shadow .2s ease, border-color .2s ease;box-shadow:0 4px 18px rgba(0,0,0,.2);color:var(--lg-text)}
+.btn:hover{transform:translateY(-1px);box-shadow:0 8px 28px rgba(0,0,0,.28)}
+.btn-primary{background:linear-gradient(180deg, rgba(79,140,255,.9), rgba(79,140,255,.6));border-color:rgba(79,140,255,.5)}
+.btn-secondary{background:linear-gradient(180deg, rgba(167,139,250,.9), rgba(167,139,250,.6));border-color:rgba(167,139,250,.5)}
+
+/* Inputs (global upgrade) */
+input[type="text"],input[type="password"],input[type="email"],input[type="number"],input[type="url"],input[type="search"],input[type="tel"],input:not([type]),select,textarea{
+  width:100%;padding:.7rem .9rem;border-radius:14px;border:1px solid rgba(255,255,255,.18);background:rgba(255,255,255,.06);color:var(--lg-text);outline:none;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);transition:border-color .2s ease, box-shadow .2s ease, background-color .2s ease
+}
+input::placeholder,textarea::placeholder{color:rgba(232,236,241,.6)}
+input:focus,select:focus,textarea:focus{border-color:rgba(79,140,255,.6);box-shadow:0 0 0 4px rgba(79,140,255,.25)}
+button[type="submit"],button.primary,input[type="submit"]{display:inline-flex;align-items:center;justify-content:center;padding:.65rem 1rem;border-radius:9999px;font-weight:700;border:1px solid rgba(79,140,255,.5);background:linear-gradient(180deg, rgba(79,140,255,.9), rgba(79,140,255,.6));color:white;cursor:pointer;backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);transition:transform .08s ease, box-shadow .2s ease;box-shadow:0 6px 22px rgba(79,140,255,.4)}
+button[type="submit"]:hover,button.primary:hover,input[type="submit"]:hover{transform:translateY(-1px)}
+
+/* Cells & segmented */
+.cell{display:flex;align-items:center;justify-content:space-between;gap:1rem;padding:.9rem 1rem;border-radius:16px;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.14);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px)}
+.segmented{display:inline-flex;gap:.25rem;padding:.25rem;border-radius:9999px;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.14);backdrop-filter:blur(10px)}
+.segmented button{border:0;border-radius:9999px;padding:.45rem .9rem;font-weight:600;color:var(--lg-text);background:transparent;cursor:pointer}
+.segmented button.active{background:linear-gradient(180deg, rgba(255,255,255,.18), rgba(255,255,255,.08));box-shadow:inset 0 0 0 1px rgba(255,255,255,.18)}
+
+/* Toggle */
+.toggle{--w:42px;--h:26px;width:var(--w);height:var(--h);background:rgba(255,255,255,.12);border:1px solid rgba(255,255,255,.18);border-radius:9999px;position:relative;cursor:pointer;transition:background .2s ease}
+.toggle::after{content:"";position:absolute;top:2px;left:2px;width:calc(var(--h) - 4px);height:calc(var(--h) - 4px);border-radius:50%;background:white;box-shadow:0 1px 6px rgba(0,0,0,.3);transition:transform .2s ease}
+.toggle.active{background:rgba(79,140,255,.65);border-color:rgba(79,140,255,.6)}
+.toggle.active::after{transform:translateX(calc(var(--w) - var(--h)))}
+
+/* Layout helpers */
+.max-w-shell{max-width:1120px;margin-left:auto;margin-right:auto}
+.pad-shell{padding:1rem}.pad-shell-lg{padding:1.25rem}
+.round-2xl{border-radius:var(--r-2xl)} .shadow-2{box-shadow:var(--sh2)}
+.bg-glass{background:rgba(255,255,255,.08)} .border-glass{border:1px solid rgba(255,255,255,.18)} .backdrop{backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px)}
+
+/* iOS26: shrinking nav on scroll */
+.lg-nav{transition:backdrop-filter .2s ease, transform .2s ease, padding .2s ease}
+.lg-nav.shrink{transform:translateY(-4px);padding-top:.35rem;padding-bottom:.35rem;border-bottom:1px solid rgba(255,255,255,.18)}

--- a/app/templates/_flash.html
+++ b/app/templates/_flash.html
@@ -1,5 +1,5 @@
 {% for category, message in messages %}
-  <div class="mb-4 px-4 py-2 rounded border text-sm {% if category=='success' %}bg-green-100 text-green-800 border-green-300{% elif category=='danger' %}bg-red-100 text-red-800 border-red-300{% else %}bg-blue-100 text-blue-800 border-blue-300{% endif %}">
+  <div class="lg-glass lg-card round-2xl mb-4 text-sm {{ 'text-green-400' if category=='success' else ('text-red-400' if category=='danger' else 'text-blue-400') }}">
     {{ message }}
   </div>
 {% endfor %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -8,17 +8,17 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
   {% block head %}{% endblock %}
 </head>
-<body class="min-h-screen bg-gradient-to-br from-blue-100 to-white text-gray-800 flex flex-col">
-  <header class="bg-blue-950 text-white">
-    <div class="max-w-4xl mx-auto px-4 py-3 flex justify-between items-center">
+<body class="min-h-screen ios26-bg text-gray-100 flex flex-col">
+  <header class="lg-bar text-white lg-nav py-3">
+    <div class="max-w-shell mx-auto pad-shell flex justify-between items-center">
       <a href="{{ url_for('routes.home') }}" class="font-bold">Tokatap</a>
       <nav class="space-x-4 text-sm">
-        <a href="{{ url_for('routes.user_login') }}" class="hover:underline">Login</a>
-        <a href="{{ url_for('routes.user_signup') }}" class="hover:underline">Sign Up</a>
+        <a href="{{ url_for('routes.user_login') }}" class="hover:opacity-90">Login</a>
+        <a href="{{ url_for('routes.user_signup') }}" class="hover:opacity-90">Sign Up</a>
       </nav>
     </div>
   </header>
-  <main class="flex-1 max-w-4xl mx-auto w-full px-4 py-6">
+  <main class="flex-1 pad-shell max-w-shell w-full mx-auto">
     {% with messages = get_flashed_messages(with_categories=true) %}
       {% if messages %}
         {% include '_flash.html' %}
@@ -26,15 +26,29 @@
     {% endwith %}
     {% block content %}{% endblock %}
   </main>
-  <footer class="bg-blue-950 text-blue-100 py-6 text-center text-xs">
-    <div class="max-w-4xl mx-auto flex flex-col items-center gap-1">
+  <footer class="lg-footer text-blue-100 py-6 text-center text-xs">
+    <div class="max-w-shell mx-auto flex flex-col items-center gap-1">
       <div><span class="font-bold">Tokatap</span> &copy; 2025. All rights reserved.</div>
       <div class="flex gap-4 mt-1">
-        <a href="{{ url_for('routes.setup_guide_page') }}" class="hover:text-white">Setup Guide</a>
-        <a href="{{ url_for('routes.faq_page') }}" class="hover:text-white">FAQ</a>
+        <a href="{{ url_for('routes.setup_guide_page') }}" class="hover:opacity-90">Setup Guide</a>
+        <a href="{{ url_for('routes.faq_page') }}" class="hover:opacity-90">FAQ</a>
       </div>
     </div>
   </footer>
-  {% block scripts %}{% endblock %}
+  {% block scripts %}
+    <script>
+      (function(){
+        const nav = document.querySelector('.lg-nav');
+        if(!nav) return;
+        let last = 0;
+        window.addEventListener('scroll', ()=>{
+          const y = window.scrollY || 0;
+          const shrinking = y > 16 && y >= last;
+          nav.classList.toggle('shrink', shrinking);
+          last = y;
+        }, {passive:true});
+      })();
+    </script>
+  {% endblock %}
 </body>
 </html>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,40 +1,32 @@
 {% extends "base.html" %}
 {% block title %}Tokatap - Login{% endblock %}
 {% block content %}
-<div class="bg-white/30 backdrop-blur-xl border border-white/20 rounded-2xl shadow-xl w-full max-w-sm mx-auto mt-10 relative overflow-hidden pb-28 text-center">
+<div class="lg-glass lg-card-lg round-2xl w-full max-w-sm mx-auto mt-10 text-center relative overflow-hidden pb-28">
   <img src="{{ url_for('static', filename='logo/logo.svg') }}" alt="Tokatap Logo" class="w-56 sm:w-64 h-auto mx-auto mt-4 object-contain logo-fade z-10 relative">
-  <h2 class="text-2xl font-bold text-slate-800 mt-2">Welcome</h2>
-  <p class="text-sm text-slate-600 mt-2 mb-6 px-4 leading-relaxed">
+  <div class="h2 mt-2">Welcome</div>
+  <p class="text-dim mt-2 mb-6 px-4 leading-relaxed">
     Know your machine’s full service history, upcoming maintenance needs, and past component changes — all in one place with just one tap or scan.
   </p>
   <form method="POST" class="space-y-4 text-left px-4">
     <div>
-      <label for="email" class="block text-sm font-medium text-slate-600 mb-1">Email</label>
-      <input id="email" type="email" name="email" required placeholder="you@example.com"
-             class="w-full px-4 py-2 rounded-xl bg-white/50 border border-white/20 shadow-inner text-slate-800 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-400">
+      <label for="email" class="block text-sm font-medium mb-1">Email</label>
+      <input id="email" type="email" name="email" required placeholder="you@example.com">
     </div>
     <div>
-      <label for="password" class="block text-sm font-medium text-slate-600 mb-1">Password</label>
-      <input id="password" type="password" name="password" required placeholder="••••••••"
-             class="w-full px-4 py-2 rounded-xl bg-white/50 border border-white/20 shadow-inner text-slate-800 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-400">
+      <label for="password" class="block text-sm font-medium mb-1">Password</label>
+      <input id="password" type="password" name="password" required placeholder="••••••••">
       <div class="text-right mt-1">
-        <a href="{{ url_for('routes.forgot_password') }}" class="text-xs text-blue-600 hover:underline">Forgot Password?</a>
+        <a href="{{ url_for('routes.forgot_password') }}" class="text-xs text-blue-400 hover:underline">Forgot Password?</a>
       </div>
     </div>
-    <button type="submit"
-            class="w-full py-2 bg-blue-600 text-white font-semibold rounded-xl shadow-lg transition-all duration-300 transform hover:scale-105 active:scale-95 hover:bg-blue-700">
-      Login
-    </button>
+    <button type="submit" class="btn btn-primary w-full justify-center">Login</button>
   </form>
-  <div class="mt-6 text-sm text-slate-600">
-    <p>New user? <a href="{{ url_for('routes.user_signup') }}" class="text-blue-600 hover:underline">Sign up here</a></p>
-    <p class="mt-2"><a href="{{ url_for('routes.home') }}" class="text-blue-600 hover:underline">← Back to Home</a></p>
+  <div class="mt-6 text-sm text-dim">
+    <p>New user? <a href="{{ url_for('routes.user_signup') }}" class="text-blue-400 hover:underline">Sign up here</a></p>
+    <p class="mt-2"><a href="{{ url_for('routes.home') }}" class="text-blue-400 hover:underline">← Back to Home</a></p>
   </div>
   <div class="flex justify-end mt-4 px-4">
-    <a href="{{ url_for('routes.subuser_login') }}"
-       class="px-4 py-1.5 bg-blue-50 border border-blue-300 text-blue-700 hover:bg-blue-100 hover:border-blue-500 font-medium rounded-full shadow-sm transition-all duration-200 text-xs">
-      Sub-User Login (using code)
-    </a>
+    <a href="{{ url_for('routes.subuser_login') }}" class="btn btn-secondary text-xs">Sub-User Login (using code)</a>
   </div>
   <div class="absolute bottom-0 left-[-60px] w-48 sm:w-56 overflow-hidden">
     <img src="{{ url_for('static', filename='logo/octatoka.png') }}" alt="Tokatap Mascot" class="mascot-float pointer-events-none select-none">

--- a/app/templates/manage_subusers.html
+++ b/app/templates/manage_subusers.html
@@ -1,42 +1,40 @@
 {% extends "base.html" %}
 {% block title %}Manage Sub-users{% endblock %}
 {% block content %}
-<div class="max-w-2xl mx-auto mb-6 space-y-4">
-  <div class="flex justify-between items-center">
-    <h1 class="text-2xl font-bold mb-4 text-slate-800 leading-tight">Manage<br><span class="text-blue-700">Sub-users</span></h1>
-    <a href="{{ url_for('routes.create_subuser') }}" class="inline-flex items-center px-4 py-1.5 border border-blue-400 text-blue-600 hover:text-blue-800 rounded-xl text-sm font-medium hover:bg-blue-50 transition shadow-sm">← Back to Previous Page</a>
+<div class="lg-glass lg-card-lg round-2xl mb-6 max-w-2xl mx-auto">
+  <div class="flex justify-between items-center mb-4">
+    <div class="h2">Manage Sub-users</div>
+    <a href="{{ url_for('routes.create_subuser') }}" class="btn btn-secondary text-sm">← Back to Previous Page</a>
   </div>
-  <div class="bg-white/10 backdrop-blur-xl border border-white/20 shadow-xl rounded-2xl p-6">
-    {% if subusers %}
-    <div class="space-y-6">
-      {% for sub in subusers %}
-      <form method="POST" class="bg-white/20 backdrop-blur border border-white/20 rounded-xl p-4 shadow space-y-4">
-        <input type="hidden" name="sub_id" value="{{ sub.id }}">
-        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-          <div class="flex-1">
-            <label for="name_{{ sub.id }}" class="block text-sm font-medium mb-1">Sub-user Name</label>
-            <input id="name_{{ sub.id }}" type="text" name="name" value="{{ sub.name }}" class="w-full px-3 py-2 border rounded-xl bg-white/50 backdrop-blur border-white/20 placeholder-slate-500 text-slate-800 text-sm" required>
-          </div>
-          <div class="flex-1">
-            <label for="machine_{{ sub.id }}" class="block text-sm font-medium mb-1">Assigned Machine</label>
-            <select id="machine_{{ sub.id }}" name="machine_id" class="w-full px-3 py-2 border rounded-xl bg-white/50 backdrop-blur border-white/20 text-slate-800 text-sm" required>
-              <option value="">Select a machine</option>
-              {% for m in machines %}
-              <option value="{{ m.id }}" {% if sub.assigned_machine_id == m.id %}selected{% endif %}>{{ m.name }} ({{ m.type }})</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="flex flex-col gap-2 sm:items-center mt-4 sm:mt-0 sm:flex-row">
-            <button type="submit" name="action" value="update" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-xl text-sm shadow-md">Update</button>
-            <button type="submit" name="action" value="delete" onclick="return confirm('Are you sure you want to delete this sub-user?')" class="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-xl text-sm shadow-md">Delete</button>
-          </div>
+  {% if subusers %}
+  <div class="space-y-6">
+    {% for sub in subusers %}
+    <form method="POST" class="lg-glass lg-card round-2xl space-y-4">
+      <input type="hidden" name="sub_id" value="{{ sub.id }}">
+      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div class="flex-1">
+          <label for="name_{{ sub.id }}" class="block text-sm font-medium mb-1">Sub-user Name</label>
+          <input id="name_{{ sub.id }}" type="text" name="name" value="{{ sub.name }}" required>
         </div>
-      </form>
-      {% endfor %}
-    </div>
-    {% else %}
-      <p class="text-slate-600">No sub-users created yet.</p>
-    {% endif %}
+        <div class="flex-1">
+          <label for="machine_{{ sub.id }}" class="block text-sm font-medium mb-1">Assigned Machine</label>
+          <select id="machine_{{ sub.id }}" name="machine_id" required>
+            <option value="">Select a machine</option>
+            {% for m in machines %}
+            <option value="{{ m.id }}" {% if sub.assigned_machine_id == m.id %}selected{% endif %}>{{ m.name }} ({{ m.type }})</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="flex flex-col gap-2 sm:items-center mt-4 sm:mt-0 sm:flex-row">
+          <button type="submit" name="action" value="update" class="btn btn-primary text-sm">Update</button>
+          <button type="submit" name="action" value="delete" onclick="return confirm('Are you sure you want to delete this sub-user?')" class="btn btn-secondary text-sm">Delete</button>
+        </div>
+      </div>
+    </form>
+    {% endfor %}
   </div>
+  {% else %}
+    <div class="lg-glass lg-card round-2xl text-dim">No sub-users created yet.</div>
+  {% endif %}
 </div>
 {% endblock %}

--- a/app/templates/service_logs.html
+++ b/app/templates/service_logs.html
@@ -1,46 +1,35 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Service Logs - Tokatap</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <script src="https://cdn.tailwindcss.com"></script>
-</head>
-<body class="bg-gradient-to-br from-blue-100 to-white min-h-screen px-2 py-6">
-
-  <div class="max-w-lg mx-auto bg-white/50 border border-white/20 rounded-2xl shadow-lg p-6 mt-6">
-    <h2 class="text-xl font-bold mb-6 text-blue-800">Service Logs</h2>
-    {% if logs %}
-      <div class="space-y-4">
-        {% for log in logs %}
-          <div class="p-4 rounded-xl border border-slate-200 bg-white/80 shadow-sm flex items-center justify-between">
-            <div>
-              <div class="font-semibold text-slate-800">{{ log.description }}</div>
-              <div class="text-xs text-slate-500 mt-1">
-                {{ log.timestamp.strftime('%d %b %Y, %I:%M %p') if log.timestamp else '' }}
-                {% if log.status %}
-                  • <span class="font-bold {{ 'text-green-700' if log.status == 'Completed' else 'text-orange-600' }}">
-                    {{ log.status }}
-                  </span>
-                {% endif %}
-              </div>
-            </div>
-            {% if log.status != 'Completed' and current_user.is_authenticated %}
-              <form method="POST" action="{{ url_for('routes.complete_service_log', log_id=log.id) }}">
-                <button type="submit" class="px-3 py-1 rounded-lg bg-green-500 text-white text-xs font-bold hover:bg-green-600 transition">Mark Complete</button>
-              </form>
-            {% endif %}
-          </div>
-        {% endfor %}
+{% extends "base.html" %}
+{% block title %}Service Logs - Tokatap{% endblock %}
+{% block content %}
+<div class="lg-glass lg-card-lg round-2xl mb-6 max-w-lg mx-auto">
+  <div class="h2 mb-2">Service Logs</div>
+  {% if logs %}
+  <div class="space-y-2">
+    {% for log in logs %}
+    <div class="cell">
+      <div>
+        <div>{{ log.description }}</div>
+        <div class="text-xs text-dim mt-1">
+          {{ log.timestamp.strftime('%d %b %Y, %I:%M %p') if log.timestamp else '' }}
+          {% if log.status %}
+          • <span class="{{ 'text-green-400' if log.status == 'Completed' else 'text-warning' }}">{{ log.status }}</span>
+          {% endif %}
+        </div>
       </div>
-    {% else %}
-      <div class="text-center text-slate-500 py-8">
-        No service logs found for this tag yet.
-      </div>
-    {% endif %}
-    <div class="mt-6 flex justify-between">
-      <a href="{{ url_for('routes.scan_service', service_tag_id=service_tag.id) }}" class="text-blue-700 hover:underline">← Back</a>
-      <a href="{{ url_for('routes.add_service_log', service_tag_id=service_tag.id) }}" class="text-blue-700 hover:underline">Log New Service</a>
+      {% if log.status != 'Completed' and current_user.is_authenticated %}
+      <form method="POST" action="{{ url_for('routes.complete_service_log', log_id=log.id) }}">
+        <button type="submit" class="btn btn-primary text-xs">Mark Complete</button>
+      </form>
+      {% endif %}
     </div>
+    {% endfor %}
   </div>
-</body>
-</html>
+  {% else %}
+  <div class="lg-glass lg-card round-2xl text-dim">No service logs found for this tag yet.</div>
+  {% endif %}
+  <div class="mt-6 flex justify-between">
+    <a href="{{ url_for('routes.scan_service', service_tag_id=service_tag.id) }}" class="btn btn-secondary">← Back</a>
+    <a href="{{ url_for('routes.add_service_log', service_tag_id=service_tag.id) }}" class="btn btn-primary">Log New Service</a>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/service_options.html
+++ b/app/templates/service_options.html
@@ -101,7 +101,8 @@
 </div>
 {% endblock %}
 {% block scripts %}
-<script>
+  {{ super() }}
+  <script>
 function openModal(){
   document.getElementById('serviceModal').classList.remove('hidden');
   document.getElementById('serviceModalBackdrop').classList.remove('hidden');
@@ -110,5 +111,5 @@ function closeModal(){
   document.getElementById('serviceModal').classList.add('hidden');
   document.getElementById('serviceModalBackdrop').classList.add('hidden');
 }
-</script>
+  </script>
 {% endblock %}

--- a/app/templates/sub_service_log.html
+++ b/app/templates/sub_service_log.html
@@ -72,12 +72,13 @@
 </div>
 {% endblock %}
 {% block scripts %}
-<script>
+  {{ super() }}
+  <script>
 const btn=document.getElementById('expandBtn');
 const form=document.getElementById('logForm');
 btn.addEventListener('click',()=>{
   form.classList.toggle('collapsed');
   form.classList.toggle('expanded');
 });
-</script>
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- introduce iOS 26 "Liquid Glass" theme variables, buttons, and components
- convert base layout and key templates to use glass cards and normalized controls
- add nav shrink script and consistent flash/toast styling
- fix script blocks to avoid missing parent errors and ensure nav script loads on pages with custom JS

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689563de522083268d0590fc612edf35