### PR TITLE
Add custom internal server error page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, render_template
 from flask_login import LoginManager
 from dotenv import load_dotenv
 from sqlalchemy import text
@@ -52,6 +52,10 @@ def create_app():
     # ✅ Register blueprints
     from app.routes import routes
     app.register_blueprint(routes)
+
+    @app.errorhandler(500)
+    def internal_server_error(error):
+        return render_template("500.html"), 500
 
     return app
 

--- a/app/templates/500.html
+++ b/app/templates/500.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block title %}Something went wrong{% endblock %}
+{% block content %}
+<div class="text-center py-20">
+  <h1 class="text-4xl font-bold text-red-600 mb-4">Oh no! Something went wrong.</h1>
+  <p class="mb-8">An unexpected error occurred. Please try again later.</p>
+  <a href="{{ url_for('routes.home') }}" class="text-blue-600 hover:underline">Return to the home page</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Render friendly message when a 500 error occurs
- Add dedicated 500.html template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5aa91dc848326b732cf7475c2ebf3