### PR TITLE
Fix recovery ingest and disable QR generation during recovery

### DIFF
--- a/app/templates/recovery_scanner.html
+++ b/app/templates/recovery_scanner.html
@@ -30,6 +30,46 @@
         <button id="submit-text" class="bg-amber-600 hover:bg-amber-700 text-white font-semibold rounded-xl py-2 px-4 shadow w-full sm:w-auto">Submit</button>
       </div>
     </div>
+
+    {% if session.get('recovery_batch_id') %}
+    <div class="bg-white/70 backdrop-blur-md border border-white/30 p-5 rounded-xl space-y-3 shadow">
+      <div class="flex items-center justify-between">
+        <div>
+          <h2 class="text-lg font-semibold">Attach Machine to Recovered Batch</h2>
+          <p class="text-sm text-slate-600">Batch ID: <strong>{{ session.get('recovery_batch_id') }}</strong></p>
+        </div>
+        <span class="text-xs font-semibold text-green-700 bg-green-100 px-2 py-1 rounded-full">Recovery</span>
+      </div>
+      <p class="text-sm text-slate-700">Attach machine details to this recovered batch. No new QR codes will be generated while in Recovery Mode.</p>
+      <form method="POST" action="{{ url_for('routes.recovery_attach_machine') }}" class="space-y-3">
+        <div>
+          <label class="block text-sm font-semibold mb-1">Machine Name</label>
+          <input type="text" name="name" class="w-full px-4 py-2 rounded-xl bg-white/70 border border-white/40 shadow-inner" placeholder="e.g., Main Unit" required>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <label class="block text-sm font-semibold mb-1">Type/Location</label>
+            <input type="text" name="type" class="w-full px-4 py-2 rounded-xl bg-white/70 border border-white/40 shadow-inner" placeholder="e.g., Factory Floor">
+          </div>
+          <div>
+            <label class="block text-sm font-semibold mb-1">Number of Heads</label>
+            <input type="number" name="num_heads" min="1" value="{{ session.get('recovery_num_heads', 8) }}" class="w-full px-4 py-2 rounded-xl bg-white/70 border border-white/40 shadow-inner">
+          </div>
+          <div>
+            <label class="block text-sm font-semibold mb-1">Needles per Head</label>
+            <input type="number" name="needles_per_head" min="1" value="15" class="w-full px-4 py-2 rounded-xl bg-white/70 border border-white/40 shadow-inner">
+          </div>
+        </div>
+        <div class="text-right">
+          <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white font-semibold rounded-xl py-2 px-4 shadow">Attach Machine</button>
+        </div>
+      </form>
+    </div>
+    {% else %}
+    <div class="bg-white/70 backdrop-blur-md border border-white/30 p-4 rounded-xl shadow text-sm text-slate-700">
+      Scan the Master QR first to set a recovery batch before attaching a machine.
+    </div>
+    {% endif %}
   </div>
 
   <script>


### PR DESCRIPTION
## Summary
- add robust Postgres sequence reset helper keyed to model tables and use it during recovery
- stop generating new QR heads when recovery mode is active and add recovery-specific machine attach flow
- harden recovery ingest to avoid master-scan errors and surface recovery machine form in the scanner UI

## Testing
- python -m compileall app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d25a9d7548326b050220b8fc7196c)